### PR TITLE
SLING-7508: fixed endless recursion getModelClassForResource()

### DIFF
--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -319,7 +319,11 @@ final class AdapterImplementations {
                 }
             }
             Resource resourceTypeResource = resolver.getResource(originalResourceType);
-            return getModelClassForResource(resourceTypeResource, map);
+            if (resourceTypeResource != null && !resourceTypeResource.getPath().equals(resource.getPath())) {
+                return getModelClassForResource(resourceTypeResource, map);
+            } else {
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
check if the resourceTypeResource differs from the resource to prevent endless recursion