### PR TITLE
SLING-8781 use model's bundle context

### DIFF
--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -629,8 +629,9 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
 
         final Map<ValuePreparer, Object> preparedValues = new HashMap<>(VALUE_PREPARERS_COUNT);
         List<MissingElementException> missingElements = null;
+        final BundleContext modelContext = getModelBundleContext(modelClass);
         for (InjectableMethod method : injectableMethods) {
-            RuntimeException t = injectElement(method, adaptable, registry, callback, preparedValues, getModelBundleContext(modelClass));
+            RuntimeException t = injectElement(method, adaptable, registry, callback, preparedValues, modelContext);
             if (t != null) {
                 if (missingElements == null) {
                     missingElements = new ArrayList<>();

--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -67,6 +67,7 @@ import org.apache.sling.models.factory.ModelClassException;
 import org.apache.sling.models.factory.ModelFactory;
 import org.apache.sling.models.factory.PostConstructException;
 import org.apache.sling.models.factory.ValidationException;
+import org.apache.sling.models.impl.injectors.OSGiServiceInjector;
 import org.apache.sling.models.impl.model.ConstructorParameter;
 import org.apache.sling.models.impl.model.InjectableElement;
 import org.apache.sling.models.impl.model.InjectableField;
@@ -88,8 +89,10 @@ import org.apache.sling.models.spi.injectorspecific.StaticInjectAnnotationProces
 import org.apache.sling.scripting.api.BindingsValuesProvidersByContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -496,7 +499,8 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
     @Nullable
     RuntimeException injectElement(final InjectableElement element, final Object adaptable,
                                    final @NotNull DisposalCallbackRegistry registry, final InjectCallback callback,
-                                   final @NotNull Map<ValuePreparer, Object> preparedValues) {
+                                   final @NotNull Map<ValuePreparer, Object> preparedValues,
+                                   final @Nullable BundleContext modelContext) {
 
         InjectAnnotationProcessor annotationProcessor = null;
         String source = element.getSource();
@@ -552,8 +556,12 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
                             preparedValues.put(preparer, preparedValue);
                         }
                     }
-
-                    Object value = injector.getValue(preparedValue, name, element.getType(), element.getAnnotatedElement(), registry);
+                    Object value = null;
+                    if (injector instanceof OSGiServiceInjector) {
+                        value = ((OSGiServiceInjector)injector).getValue(preparedValue, name, element.getType(), element.getAnnotatedElement(), registry, modelContext);
+                    } else {
+                        value = injector.getValue(preparedValue, name, element.getType(), element.getAnnotatedElement(), registry);
+                    }
                     if (value != null) {
                         lastInjectionException = callback.inject(element, value);
                         if (lastInjectionException == null) {
@@ -602,6 +610,15 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         return null;
     }
 
+    private BundleContext getModelBundleContext(final ModelClass<?> modelClass) {
+        BundleContext modelContext = null;
+        Bundle modelBundle = FrameworkUtil.getBundle(modelClass.getType());
+        if (modelBundle != null) {
+            return modelBundle.getBundleContext();
+        }
+        return null;
+    }
+
     private <ModelType> Result<InvocationHandler> createInvocationHandler(final Object adaptable, final ModelClass<ModelType> modelClass) {
         InjectableMethod[] injectableMethods = modelClass.getInjectableMethods();
         final Map<Method, Object> methods = new HashMap<>();
@@ -611,10 +628,9 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         DisposalCallbackRegistryImpl registry = new DisposalCallbackRegistryImpl();
 
         final Map<ValuePreparer, Object> preparedValues = new HashMap<>(VALUE_PREPARERS_COUNT);
-
         List<MissingElementException> missingElements = null;
         for (InjectableMethod method : injectableMethods) {
-            RuntimeException t = injectElement(method, adaptable, registry, callback, preparedValues);
+            RuntimeException t = injectElement(method, adaptable, registry, callback, preparedValues, getModelBundleContext(modelClass));
             if (t != null) {
                 if (missingElements == null) {
                     missingElements = new ArrayList<>();
@@ -702,9 +718,9 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
 
         InjectableField[] injectableFields = modelClass.getInjectableFields();
         List<MissingElementException> missingElements = null;
-
+        final BundleContext modelContext = getModelBundleContext(modelClass);
         for (InjectableField field : injectableFields) {
-            RuntimeException t = injectElement(field, adaptable, registry, callback, preparedValues);
+            RuntimeException t = injectElement(field, adaptable, registry, callback, preparedValues, modelContext);
             if (t != null) {
                 if (missingElements == null) {
                     missingElements = new ArrayList<>();
@@ -781,9 +797,10 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         List<Object> paramValues = new ArrayList<>(Arrays.asList(new Object[parameters.length]));
         InjectCallback callback = new SetConstructorParameterCallback(paramValues);
 
+        final BundleContext modelContext = getModelBundleContext(modelClass);
         List<MissingElementException> missingElements = null;
         for (int i = 0; i < parameters.length; i++) {
-            RuntimeException t = injectElement(parameters[i], adaptable, registry, callback, preparedValues);
+            RuntimeException t = injectElement(parameters[i], adaptable, registry, callback, preparedValues, modelContext);
             if (t != null) {
                 if (missingElements == null) {
                     missingElements = new ArrayList<>();

--- a/src/main/java/org/apache/sling/models/impl/injectors/OSGiServiceInjector.java
+++ b/src/main/java/org/apache/sling/models/impl/injectors/OSGiServiceInjector.java
@@ -54,7 +54,7 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
     private static final Logger log = LoggerFactory.getLogger(OSGiServiceInjector.class);
 
     private BundleContext bundleContext;
-    
+
     @Override
     public @NotNull String getName() {
         return "osgi-services";

--- a/src/main/java/org/apache/sling/models/impl/injectors/OSGiServiceInjector.java
+++ b/src/main/java/org/apache/sling/models/impl/injectors/OSGiServiceInjector.java
@@ -37,8 +37,6 @@ import org.apache.sling.models.spi.Injector;
 import org.apache.sling.models.spi.injectorspecific.AbstractInjectAnnotationProcessor2;
 import org.apache.sling.models.spi.injectorspecific.InjectAnnotationProcessor2;
 import org.apache.sling.models.spi.injectorspecific.StaticInjectAnnotationProcessorFactory;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.scripting.SlingBindings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
@@ -56,9 +54,7 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
     private static final Logger log = LoggerFactory.getLogger(OSGiServiceInjector.class);
 
     private BundleContext bundleContext;
-
-    private BundleContext modelBundleContext = null;
-
+    
     @Override
     public @NotNull String getName() {
         return "osgi-services";
@@ -99,24 +95,7 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
                 filterString = filter.value();
             }
         }
-        if (adaptable instanceof SlingHttpServletRequest && StringUtils.isBlank(filterString) && type instanceof Class<?>) {
-            //in that case, we'll try to serve the service reference from the request bindings,
-            //as it's probably already cached.
-            SlingHttpServletRequest request = (SlingHttpServletRequest) adaptable;
-            Object service = getValueFromBindings(request, (Class<?>)type);
-            if (service != null) {
-                return service;
-            }
-        }
         return getValue(adaptable, type, filterString, callbackRegistry, modelContext == null ? bundleContext : modelContext);
-    }
-
-    private <T> Object getValueFromBindings(final SlingHttpServletRequest request, Class<T> type) {
-        SlingBindings bindings = (SlingBindings) request.getAttribute(SlingBindings.class.getName());
-        if (bindings != null && bindings.getSling() != null) {
-            return bindings.getSling().getService(type);
-        }
-        return null;
     }
 
     private <T> Object getService(Object adaptable, Class<T> type, String filter,

--- a/src/main/java/org/apache/sling/models/impl/injectors/OSGiServiceInjector.java
+++ b/src/main/java/org/apache/sling/models/impl/injectors/OSGiServiceInjector.java
@@ -40,6 +40,7 @@ import org.apache.sling.models.spi.injectorspecific.StaticInjectAnnotationProces
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
@@ -56,6 +57,8 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
 
     private BundleContext bundleContext;
 
+    private BundleContext modelBundleContext = null;
+
     @Override
     public @NotNull String getName() {
         return "osgi-services";
@@ -69,6 +72,21 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
     @Override
     public Object getValue(@NotNull Object adaptable, String name, @NotNull Type type, @NotNull AnnotatedElement element,
             @NotNull DisposalCallbackRegistry callbackRegistry) {
+        return getValue(adaptable, name, type, element, callbackRegistry, bundleContext);
+    }
+
+    /**
+     *
+     * @param adaptable
+     * @param name
+     * @param type
+     * @param element
+     * @param callbackRegistry
+     * @param modelContext
+     * @return
+     */
+    public Object getValue(@NotNull Object adaptable, String name, @NotNull Type type, @NotNull AnnotatedElement element,
+                           @NotNull DisposalCallbackRegistry callbackRegistry, @Nullable BundleContext modelContext) {
         OSGiService annotation = element.getAnnotation(OSGiService.class);
         String filterString = null;
         if (annotation != null) {
@@ -90,7 +108,7 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
                 return service;
             }
         }
-        return getValue(adaptable, type, filterString, callbackRegistry);
+        return getValue(adaptable, type, filterString, callbackRegistry, modelContext == null ? bundleContext : modelContext);
     }
 
     private <T> Object getValueFromBindings(final SlingHttpServletRequest request, Class<T> type) {
@@ -102,18 +120,18 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
     }
 
     private <T> Object getService(Object adaptable, Class<T> type, String filter,
-            DisposalCallbackRegistry callbackRegistry) {
+            DisposalCallbackRegistry callbackRegistry, BundleContext modelContext) {
         // cannot use SlingScriptHelper since it does not support ordering by service ranking due to https://issues.apache.org/jira/browse/SLING-5665
         try {
-            ServiceReference<?>[] refs = bundleContext.getServiceReferences(type.getName(), filter);
+            ServiceReference<?>[] refs = modelContext.getServiceReferences(type.getName(), filter);
             if (refs == null || refs.length == 0) {
                 return null;
             } else {
                 // sort by service ranking (lowest first) (see ServiceReference.compareTo)
                 List<ServiceReference<?>> references = Arrays.asList(refs);
                 Collections.sort(references);
-                callbackRegistry.addDisposalCallback(new Callback(refs, bundleContext));
-                return bundleContext.getService(references.get(references.size() - 1));
+                callbackRegistry.addDisposalCallback(new Callback(refs, modelContext));
+                return modelContext.getService(references.get(references.size() - 1));
             }
         } catch (InvalidSyntaxException e) {
             log.error("invalid filter expression", e);
@@ -122,10 +140,10 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
     }
 
     private <T> Object[] getServices(Object adaptable, Class<T> type, String filter,
-            DisposalCallbackRegistry callbackRegistry) {
+            DisposalCallbackRegistry callbackRegistry, BundleContext modelContext) {
         // cannot use SlingScriptHelper since it does not support ordering by service ranking due to https://issues.apache.org/jira/browse/SLING-5665
         try {
-            ServiceReference<?>[] refs = bundleContext.getServiceReferences(type.getName(), filter);
+            ServiceReference<?>[] refs = modelContext.getServiceReferences(type.getName(), filter);
             if (refs == null || refs.length == 0) {
                 return null;
             } else {
@@ -134,10 +152,10 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
                 Collections.sort(references);
                 // make highest service ranking being returned first
                 Collections.reverse(references);
-                callbackRegistry.addDisposalCallback(new Callback(refs, bundleContext));
+                callbackRegistry.addDisposalCallback(new Callback(refs, modelContext));
                 List<Object> services = new ArrayList<>();
                 for (ServiceReference<?> ref : references) {
-                    Object service = bundleContext.getService(ref);
+                    Object service = modelContext.getService(ref);
                     if (service != null) {
                         services.add(service);
                     }
@@ -150,12 +168,13 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
         }
     }
 
-    private Object getValue(Object adaptable, Type type, String filterString, DisposalCallbackRegistry callbackRegistry) {
+    private Object getValue(Object adaptable, Type type, String filterString, DisposalCallbackRegistry callbackRegistry,
+                            BundleContext modelContext) {
         if (type instanceof Class) {
             Class<?> injectedClass = (Class<?>) type;
             if (injectedClass.isArray()) {
                 Object[] services = getServices(adaptable, injectedClass.getComponentType(), filterString,
-                        callbackRegistry);
+                        callbackRegistry, modelContext);
                 if (services == null) {
                     return null;
                 }
@@ -165,7 +184,7 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
                 }
                 return arr;
             } else {
-                return getService(adaptable, injectedClass, filterString, callbackRegistry);
+                return getService(adaptable, injectedClass, filterString, callbackRegistry, modelContext);
             }
         } else if (type instanceof ParameterizedType) {
             ParameterizedType ptype = (ParameterizedType) type;
@@ -178,7 +197,7 @@ public class OSGiServiceInjector implements Injector, StaticInjectAnnotationProc
             }
 
             Class<?> serviceType = (Class<?>) ptype.getActualTypeArguments()[0];
-            Object[] services = getServices(adaptable, serviceType, filterString, callbackRegistry);
+            Object[] services = getServices(adaptable, serviceType, filterString, callbackRegistry, modelContext);
             if (services == null) {
                 return null;
             }


### PR DESCRIPTION
- add in listener register of bundle context for each model class,
- add in adapter implementations a map Model Type -> Bundle Context,
- in ModelAdapterFactory, lookup specific context, and for osgi injector specifically, call getValue with specified bundle context,
- in OsgiServiceInjector, have specific (or default legacy one) bundle context used for service references