### PR TITLE
SLING-9834 - [Sling Models] Caching bug with reused Servlet requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.testing</artifactId>
+            <version>2.0.26</version>
+        </dependency>
         <!-- for testing the annotations -->
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -421,7 +421,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
                     if (handlerResult.wasSuccessful()) {
                         ModelType model = (ModelType) Proxy.newProxyInstance(modelClass.getType().getClassLoader(), new Class<?>[] { modelClass.getType() }, handlerResult.getValue());
 
-                        if (modelAnnotation.cache()) {
+                        if (modelAnnotation.cache() && adaptableCache != null) {
                             adaptableCache.put(requestedType, new SoftReference<Object>(model));
                         }
 
@@ -433,7 +433,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
                     try {
                         result = createObject(adaptable, modelClass);
 
-                        if (result.wasSuccessful() && modelAnnotation.cache()) {
+                        if (result.wasSuccessful() && modelAnnotation.cache() && adaptableCache != null) {
                             adaptableCache.put(requestedType, new SoftReference<Object>(result.getValue()));
                         }
                     } catch (Exception e) {

--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -348,24 +348,20 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
     
     @SuppressWarnings("unchecked")
     private Map<Class<?>, SoftReference<Object>> getOrCreateCache(final Object adaptable) {
-        synchronized (adaptable) {
-            Map<Class<?>, SoftReference<Object>> adaptableCache;
-            if (adaptable instanceof ServletRequest) {
-                ServletRequest request = (ServletRequest) adaptable;
-                adaptableCache = (Map<Class<?>, SoftReference<Object>>) request.getAttribute(REQUEST_CACHE_ATTRIBUTE);
-                if (adaptableCache == null) {
-                    adaptableCache = Collections.synchronizedMap(new WeakHashMap<Class<?>, SoftReference<Object>>());
-                    request.setAttribute(REQUEST_CACHE_ATTRIBUTE, adaptableCache);
-                }
-            } else {
-                adaptableCache = adapterCache.get(adaptable);
-                if (adaptableCache == null) {
-                    adaptableCache = Collections.synchronizedMap(new WeakHashMap<Class<?>, SoftReference<Object>>());
-                    adapterCache.put(adaptable, adaptableCache);
-                }
+        Map<Class<?>, SoftReference<Object>> adaptableCache;
+        if (adaptable instanceof ServletRequest) {
+            ServletRequest request = (ServletRequest) adaptable;
+            adaptableCache = (Map<Class<?>, SoftReference<Object>>) request.getAttribute(REQUEST_CACHE_ATTRIBUTE);
+            if (adaptableCache == null) {
+                adaptableCache = Collections.synchronizedMap(new WeakHashMap<Class<?>, SoftReference<Object>>());
+                request.setAttribute(REQUEST_CACHE_ATTRIBUTE, adaptableCache);
             }
-            return adaptableCache;
+        } else {
+            adaptableCache = adapterCache.computeIfAbsent(adaptable, k -> {
+                return Collections.synchronizedMap(new WeakHashMap<Class<?>, SoftReference<Object>>());
+            });
         }
+        return adaptableCache;
     }
     
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/apache/sling/models/impl/CachingTest.java
+++ b/src/test/java/org/apache/sling/models/impl/CachingTest.java
@@ -16,32 +16,33 @@
  */
 package org.apache.sling.models.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import java.util.HashMap;
+import java.util.Map;
 
-import javax.servlet.ServletRequestWrapper;
-
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.commons.testing.sling.MockSlingHttpServletRequest;
 import org.apache.sling.models.impl.injectors.RequestAttributeInjector;
 import org.apache.sling.models.testmodels.classes.CachedModel;
 import org.apache.sling.models.testmodels.classes.UncachedModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CachingTest {
 
-    @Mock
-    private SlingHttpServletRequest request;
+    @Spy
+    private MockRequest request;
 
-    @Mock
-    private ServletRequestWrapper requestWrapper;
+    private SlingHttpServletRequestWrapper requestWrapper;
 
     private ModelAdapterFactory factory;
 
@@ -53,7 +54,7 @@ public class CachingTest {
                 org.apache.sling.models.testmodels.interfaces.CachedModel.class, org.apache.sling.models.testmodels.interfaces.UncachedModel.class);
 
         when(request.getAttribute("testValue")).thenReturn("test");
-        when(requestWrapper.getRequest()).thenReturn(request);
+        requestWrapper = new SlingHttpServletRequestWrapper(request);
     }
 
     @Test
@@ -114,6 +115,11 @@ public class CachingTest {
         assertEquals("test", cached2.getTestValue());
 
         verify(request, times(1)).getAttribute("testValue");
+        
+        // If we clear the request attributes, the sling model is no longer cached
+        request.clearAttributes();
+        CachedModel cached3 = factory.getAdapter(request, CachedModel.class);
+        assertTrue(cached1 != cached3);
     }
 
     @Test
@@ -127,4 +133,29 @@ public class CachingTest {
 
         verify(request, times(1)).getAttribute("testValue");
     }
+    
+    // MockSlingHttpServletRequest doesn't implement set and get attributes
+    private static class MockRequest extends MockSlingHttpServletRequest {
+
+        private Map<String, Object> attributes = new HashMap<>();
+        
+        MockRequest() {
+            super(null, null, null, null, null);
+        }
+        
+        @Override
+        public void setAttribute(String name, Object o) {
+            attributes.put(name, o);
+        }
+        
+        @Override
+        public Object getAttribute(String name) {
+            return attributes.get(name);
+        }
+        
+        public void clearAttributes() {
+            attributes.clear();
+        }
+    }
 }
+

--- a/src/test/java/org/apache/sling/models/testmodels/classes/CachedModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/CachedModel.java
@@ -16,12 +16,13 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.models.annotations.Model;
-
 import javax.inject.Inject;
 
-@Model(adaptables = SlingHttpServletRequest.class, cache = true)
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class}, cache = true)
 public class CachedModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/UncachedModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/UncachedModel.java
@@ -17,12 +17,13 @@
 package org.apache.sling.models.testmodels.classes;
 
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.models.annotations.Model;
-
 import javax.inject.Inject;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class UncachedModel {
 
     @Inject


### PR DESCRIPTION
- use ServletRequest attributes to cache sling models when the adaptable is a ServletRequest