### PR TITLE
SLING-10948 Update to Parent 46 and latest versions of OSGi annotation dependencies

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,6 +1,5 @@
 # Remove those package imports because embedded and relocated via shade plugin (see below)
 Import-Package:\
-    !org.apache.sling.commons.osgi,\
     !org.apache.sling.scripting.core.impl.helper,\
     *
 Provide-Capability:\

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>40</version>
+        <version>46</version>
         <relativePath />
     </parent>
     <artifactId>org.apache.sling.models.impl</artifactId>
@@ -38,13 +38,13 @@
     </scm>
     <properties>
         <sling.java.version>8</sling.java.version>
+        <project.build.outputTimestamp>2021-12-01T00:00:00Z</project.build.outputTimestamp>
     </properties>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -56,27 +56,16 @@
                             <shadeSourcesContent>true</shadeSourcesContent>
                             <artifactSet>
                                 <includes>
-                                    <include>org.apache.sling:org.apache.sling.commons.osgi</include>
                                     <include>org.apache.sling:org.apache.sling.scripting.core</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
-                                <relocation>
-                                    <pattern>org.apache.sling.commons.osgi</pattern>
-                                    <shadedPattern>slingmodelsimpl.org.apache.sling.commons.osgi</shadedPattern>
-                                </relocation>
                                 <relocation>
                                     <pattern>org.apache.sling.scripting.core.impl.helper</pattern>
                                     <shadedPattern>slingmodelsimpl.org.apache.sling.scripting.core.impl.helper</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>
-                                <filter>
-                                    <artifact>org.apache.sling:org.apache.sling.commons.osgi</artifact>
-                                    <includes>
-                                        <include>org/apache/sling/commons/osgi/**</include>
-                                    </includes>
-                                </filter>
                                 <filter>
                                     <artifact>org.apache.sling:org.apache.sling.scripting.core</artifact>
                                     <includes>
@@ -118,20 +107,17 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
-            <version>1.3.0</version> <!-- downgrade to DS 1.3 (OSGi R6), as this leads to a run time dependency -->
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.metatype.annotations</artifactId>
-            <version>1.3.0</version> <!-- downgrade to metatype 1.3 (OSGi R6) -->
             <scope>provided</scope>
         </dependency>
         <!-- regular compile-time dependencies -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.4</version><!-- still Servlet 2.4 -->
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -163,7 +149,6 @@
             <version>1</version>
             <scope>provided</scope>
         </dependency>
-        <!-- Artifact is shaded and inlined, only some classes included (see above) -->
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.osgi</artifactId>
@@ -218,11 +203,6 @@
             <scope>test</scope>
         </dependency>
         <!-- transitive depedendencies of org.apache.sling.servlet-helpers -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>


### PR DESCRIPTION
this actively drops the support for OSGi < R7 and the older DS/metatype implementations.

we also get rid of embedding org.apachesling.commons.osgi, as the required version is available for long time in recent sling releases

runs fine in Sling 11 (released 3 years ago) and up.