### PR TITLE
SLING-8079 throw PostConstructException for createModel in case

### DIFF
--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -265,7 +265,11 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
     public <AdapterType> AdapterType getAdapter(Object adaptable, Class<AdapterType> type) {
         Result<AdapterType> result = internalCreateModel(adaptable, type);
         if (!result.wasSuccessful()) {
-            log.warn("Could not adapt to model", result.getThrowable());
+            if (result == Result.POST_CONSTRUCT_PREVENTED_MODEL_CONSTRUCTION) {
+                log.warn("Could not adapt to model as PostConstruct method returned false"); // do no construct runtime exception in this case
+            } else {
+                log.warn("Could not adapt to model", result.getThrowable());
+            }
             return null;
         } else {
             return result.getValue();
@@ -359,7 +363,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
     }
 
     @SuppressWarnings("unchecked")
-    private <ModelType> Result<ModelType> internalCreateModel(final Object adaptable, final Class<ModelType> requestedType) {
+    <ModelType> Result<ModelType> internalCreateModel(final Object adaptable, final Class<ModelType> requestedType) {
         Result<ModelType> result;
         ThreadInvocationCounter threadInvocationCounter = invocationCountThreadLocal.get();
         if (threadInvocationCounter.isMaximumReached()) {
@@ -754,6 +758,9 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         }
         try {
             object = invokePostConstruct(object);
+            if (object == null) {
+                return (Result<ModelType>) Result.POST_CONSTRUCT_PREVENTED_MODEL_CONSTRUCTION;
+            }
         } catch (InvocationTargetException e) {
             return new Result<>(new PostConstructException("Post-construct method has thrown an exception for model " + modelClass.getType(), e.getCause()));
         } catch (IllegalAccessException e) {

--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -266,7 +266,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         Result<AdapterType> result = internalCreateModel(adaptable, type);
         if (!result.wasSuccessful()) {
             if (result == Result.POST_CONSTRUCT_PREVENTED_MODEL_CONSTRUCTION) {
-                log.warn("Could not adapt to model as PostConstruct method returned false"); // do no construct runtime exception in this case
+                log.debug("Could not adapt to model as PostConstruct method returned false"); // do no construct runtime exception in this case
             } else {
                 log.warn("Could not adapt to model", result.getThrowable());
             }

--- a/src/main/java/org/apache/sling/models/impl/Result.java
+++ b/src/main/java/org/apache/sling/models/impl/Result.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.models.impl;
 
+import org.apache.sling.models.factory.PostConstructException;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -88,5 +89,13 @@ public class Result<SuccessObjectType> {
         return object != null;
     }
 
+    public static final Result<Object> POST_CONSTRUCT_PREVENTED_MODEL_CONSTRUCTION = new Result<Object>((RuntimeException)null) {
 
+        @Override
+        public @NotNull RuntimeException getThrowable() {
+            // generate exception lazily
+            return new PostConstructException("PostConstruct method returned false", null);
+        }
+        
+    };
 }

--- a/src/test/java/org/apache/sling/models/impl/PostConstructTest.java
+++ b/src/test/java/org/apache/sling/models/impl/PostConstructTest.java
@@ -24,11 +24,11 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.factory.PostConstructException;
-import org.apache.sling.models.testmodels.classes.FailingPostConstuctModel;
+import org.apache.sling.models.testmodels.classes.FailingPostConstructModel;
 import org.apache.sling.models.testmodels.classes.FalsePostConstructModel;
 import org.apache.sling.models.testmodels.classes.SubClass;
 import org.apache.sling.models.testmodels.classes.SubClassOverriddenPostConstruct;
-import org.apache.sling.models.testmodels.classes.TruePostConstuctModel;
+import org.apache.sling.models.testmodels.classes.TruePostConstructModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +47,7 @@ public class PostConstructTest {
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
         // no injectors are necessary
-        factory.adapterImplementations.addClassesAsAdapterAndImplementation(SubClass.class, SubClassOverriddenPostConstruct.class, FailingPostConstuctModel.class, FalsePostConstructModel.class, TruePostConstuctModel.class);
+        factory.adapterImplementations.addClassesAsAdapterAndImplementation(SubClass.class, SubClassOverriddenPostConstruct.class, FailingPostConstructModel.class, FalsePostConstructModel.class, TruePostConstructModel.class);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class PostConstructTest {
 
     @Test
     public void testPostConstructMethodWhichThrowsException() {
-        FailingPostConstuctModel model = factory.getAdapter(resource, FailingPostConstuctModel.class);
+        FailingPostConstructModel model = factory.getAdapter(resource, FailingPostConstructModel.class);
         assertNull(model);
     }
 
@@ -78,7 +78,7 @@ public class PostConstructTest {
 
     @Test
     public void testPostConstructMethodWhichReturnsTrue() {
-        TruePostConstuctModel model = factory.getAdapter(resource, TruePostConstuctModel.class);
+        TruePostConstructModel model = factory.getAdapter(resource, TruePostConstructModel.class);
         assertNotNull(model);
     }
 
@@ -93,7 +93,7 @@ public class PostConstructTest {
 
     @Test
     public void testPostConstructMethodWhichReturnsTrueCreateModel() {
-        TruePostConstuctModel model = factory.createModel(resource, TruePostConstuctModel.class);
+        TruePostConstructModel model = factory.createModel(resource, TruePostConstructModel.class);
         assertNotNull(model);
     }
 
@@ -101,7 +101,7 @@ public class PostConstructTest {
     public void testPostConstructMethodWhichThrowsExceptionThrowingException() {
         boolean thrown = false;
         try {
-            factory.createModel(resource, FailingPostConstuctModel.class);
+            factory.createModel(resource, FailingPostConstructModel.class);
         } catch (PostConstructException e) {
             assertTrue(e.getMessage().contains("Post-construct"));
             assertEquals("FAIL", e.getCause().getMessage());

--- a/src/test/java/org/apache/sling/models/impl/PostConstructTest.java
+++ b/src/test/java/org/apache/sling/models/impl/PostConstructTest.java
@@ -19,12 +19,13 @@ package org.apache.sling.models.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.factory.PostConstructException;
 import org.apache.sling.models.testmodels.classes.FailingPostConstuctModel;
-import org.apache.sling.models.testmodels.classes.FalsePostConstuctModel;
+import org.apache.sling.models.testmodels.classes.FalsePostConstructModel;
 import org.apache.sling.models.testmodels.classes.SubClass;
 import org.apache.sling.models.testmodels.classes.SubClassOverriddenPostConstruct;
 import org.apache.sling.models.testmodels.classes.TruePostConstuctModel;
@@ -46,7 +47,7 @@ public class PostConstructTest {
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
         // no injectors are necessary
-        factory.adapterImplementations.addClassesAsAdapterAndImplementation(SubClass.class, SubClassOverriddenPostConstruct.class, FailingPostConstuctModel.class, FalsePostConstuctModel.class, TruePostConstuctModel.class);
+        factory.adapterImplementations.addClassesAsAdapterAndImplementation(SubClass.class, SubClassOverriddenPostConstruct.class, FailingPostConstuctModel.class, FalsePostConstructModel.class, TruePostConstuctModel.class);
     }
 
     @Test
@@ -71,7 +72,7 @@ public class PostConstructTest {
 
     @Test
     public void testPostConstructMethodWhichReturnsFalse() {
-        FalsePostConstuctModel model = factory.getAdapter(resource, FalsePostConstuctModel.class);
+        FalsePostConstructModel model = factory.getAdapter(resource, FalsePostConstructModel.class);
         assertNull(model);
     }
 
@@ -81,9 +82,13 @@ public class PostConstructTest {
         assertNotNull(model);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = PostConstructException.class)
     public void testPostConstructMethodWhichReturnsFalseCreateModel() {
-        factory.createModel(resource, FalsePostConstuctModel.class);
+        factory.createModel(resource, FalsePostConstructModel.class);
+    }
+
+    public void testPostConstructMethodWhichReturnsFalseInternalCreateModel() {
+        assertSame(Result.POST_CONSTRUCT_PREVENTED_MODEL_CONSTRUCTION, factory.internalCreateModel(resource, FalsePostConstructModel.class));
     }
 
     @Test

--- a/src/test/java/org/apache/sling/models/testmodels/classes/FailingPostConstructModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/FailingPostConstructModel.java
@@ -24,7 +24,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 
 @Model(adaptables=Resource.class)
-public class FailingPostConstuctModel {
+public class FailingPostConstructModel {
 
     @PostConstruct
     protected void pc() throws Exception {

--- a/src/test/java/org/apache/sling/models/testmodels/classes/FalsePostConstructModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/FalsePostConstructModel.java
@@ -24,7 +24,7 @@ import org.apache.sling.models.annotations.Model;
 import javax.annotation.PostConstruct;
 
 @Model(adaptables=Resource.class)
-public class FalsePostConstuctModel {
+public class FalsePostConstructModel {
 
     @PostConstruct
     protected boolean pc() throws Exception {

--- a/src/test/java/org/apache/sling/models/testmodels/classes/TruePostConstructModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/TruePostConstructModel.java
@@ -24,7 +24,7 @@ import org.apache.sling.models.annotations.Model;
 import javax.annotation.PostConstruct;
 
 @Model(adaptables=Resource.class)
-public class TruePostConstuctModel {
+public class TruePostConstructModel {
 
     @PostConstruct
     protected boolean pc() throws Exception {


### PR DESCRIPTION
PostConstruct method returned false

Prevent creation of exception object for simple adaptations