### PR TITLE
SLING-11073: add OriginalResourceViaProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.api</artifactId>
-            <version>1.3.6</version>
+            <version>1.4.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/models/impl/via/AbstractResourceTypeViaProvider.java
+++ b/src/main/java/org/apache/sling/models/impl/via/AbstractResourceTypeViaProvider.java
@@ -18,8 +18,6 @@ package org.apache.sling.models.impl.via;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceWrapper;
-import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
 import org.apache.sling.models.spi.ViaProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,33 +63,4 @@ public abstract class AbstractResourceTypeViaProvider implements ViaProvider {
 
     protected abstract @Nullable String getResourceType(@NotNull Resource resource, @NotNull String value);
 
-    private class ResourceTypeForcingResourceWrapper extends ResourceWrapper {
-
-        private final String resourceType;
-
-        private ResourceTypeForcingResourceWrapper(Resource resource, String resourceType) {
-            super(resource);
-            this.resourceType = resourceType;
-        }
-
-        @Override
-        public String getResourceType() {
-            return resourceType;
-        }
-    }
-
-    private class ResourceTypeForcingRequestWrapper extends SlingHttpServletRequestWrapper {
-
-        private final Resource resource;
-
-        private ResourceTypeForcingRequestWrapper(SlingHttpServletRequest request, Resource resource, String resourceType) {
-            super(request);
-            this.resource = new ResourceTypeForcingResourceWrapper(resource, resourceType);
-        }
-
-        @Override
-        public Resource getResource() {
-            return resource;
-        }
-    }
 }

--- a/src/main/java/org/apache/sling/models/impl/via/OriginalResourceViaProvider.java
+++ b/src/main/java/org/apache/sling/models/impl/via/OriginalResourceViaProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.impl.via;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.ViaProviderType;
+import org.apache.sling.models.annotations.via.OriginalResource;
+import org.apache.sling.models.spi.ViaProvider;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This {@link ViaProvider} implements the counterpart of the {@link ForcedResourceTypeViaProvider} and
+ * {@link ResourceSuperTypeViaProvider}. It is in particular helpful in models that want to inject another model using the original
+ * {@link Resource}'s or {@link SlingHttpServletRequest}'s resource type instead of the one forced by either of the above-mentioned via
+ * providers.
+ * <p>
+ * The implementation simply unwraps the {@link org.apache.sling.api.resource.ResourceWrapper} or
+ * {@link org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper} used by the {@link ForcedResourceTypeViaProvider} and
+ * {@link ResourceSuperTypeViaProvider}.
+ */
+@Component
+public class OriginalResourceViaProvider implements ViaProvider {
+
+    @Override
+    public Class<? extends ViaProviderType> getType() {
+        return OriginalResource.class;
+    }
+
+    @Override
+    public Object getAdaptable(Object original, String value) {
+        if (original instanceof SlingHttpServletRequest) {
+            SlingHttpServletRequest originalRequest = (SlingHttpServletRequest) original;
+            while (originalRequest instanceof ResourceTypeForcingRequestWrapper) {
+                originalRequest = ((ResourceTypeForcingRequestWrapper) originalRequest).getSlingRequest();
+            }
+            return originalRequest;
+        } else if (original instanceof Resource) {
+            Resource originalResource = (Resource) original;
+            while (originalResource instanceof ResourceTypeForcingResourceWrapper) {
+                originalResource = ((ResourceTypeForcingResourceWrapper) originalResource).getResource();
+            }
+            return originalResource;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/models/impl/via/ResourceTypeForcingRequestWrapper.java
+++ b/src/main/java/org/apache/sling/models/impl/via/ResourceTypeForcingRequestWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.impl.via;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+
+class ResourceTypeForcingRequestWrapper extends SlingHttpServletRequestWrapper {
+
+    private final Resource resource;
+
+    ResourceTypeForcingRequestWrapper(SlingHttpServletRequest request, Resource resource, String resourceType) {
+        super(request);
+        this.resource = new ResourceTypeForcingResourceWrapper(resource, resourceType);
+    }
+
+    @Override
+    public Resource getResource() {
+        return resource;
+    }
+}

--- a/src/main/java/org/apache/sling/models/impl/via/ResourceTypeForcingResourceWrapper.java
+++ b/src/main/java/org/apache/sling/models/impl/via/ResourceTypeForcingResourceWrapper.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.impl.via;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceWrapper;
+
+class ResourceTypeForcingResourceWrapper extends ResourceWrapper {
+
+    private final String resourceType;
+
+    ResourceTypeForcingResourceWrapper(Resource resource, String resourceType) {
+        super(resource);
+        this.resourceType = resourceType;
+    }
+
+    @Override
+    public String getResourceType() {
+        return resourceType;
+    }
+}

--- a/src/test/java/org/apache/sling/models/impl/via/OriginalResourceViaProviderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/via/OriginalResourceViaProviderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.impl.via;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceWrapper;
+import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.models.annotations.via.OriginalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OriginalResourceViaProviderTest {
+
+    private OriginalResourceViaProvider provider = new OriginalResourceViaProvider();
+
+    @Mock
+    private Resource resource;
+
+    @Mock
+    private SlingHttpServletRequest request;
+
+    @Test
+    public void testReturnsCorrectMarkerInterface() {
+        assertEquals(OriginalResource.class, provider.getType());
+    }
+
+    @Test
+    public void testReturnsOriginalResourceIfNotWrapped() {
+        Object projected = provider.getAdaptable(resource, null);
+        assertEquals(resource, projected);
+    }
+
+    @Test
+    public void testReturnsOriginalRequestIfNotWrapped() {
+        Object projected = provider.getAdaptable(request, null);
+        assertEquals(request, projected);
+    }
+
+    @Test
+    public void testReturnsNullIfNeitherRequestOrResource() {
+        Object projected = provider.getAdaptable(new Object(), null);
+        assertNull(projected);
+    }
+
+    @Test
+    public void testUnwrapsResource() {
+        // once
+        Resource testCase = new ResourceTypeForcingResourceWrapper(resource, "foo");
+        Object projected = provider.getAdaptable(testCase, null);
+        assertEquals(resource, projected);
+
+        // more than once
+        testCase = new ResourceTypeForcingResourceWrapper(testCase, "bar");
+        testCase = new ResourceTypeForcingResourceWrapper(testCase, "foobar");
+        projected = provider.getAdaptable(testCase, null);
+        assertEquals(resource, projected);
+    }
+
+    @Test
+    public void testUnwrapsRequest() {
+        // once
+        SlingHttpServletRequest testCase = new ResourceTypeForcingRequestWrapper(request, resource, "foo");
+        Object projected = provider.getAdaptable(testCase, null);
+        assertEquals(request, projected);
+
+        // more than once
+        testCase = new ResourceTypeForcingRequestWrapper(testCase, resource, "bar");
+        testCase = new ResourceTypeForcingRequestWrapper(testCase, resource, "foobar");
+        projected = provider.getAdaptable(testCase, null);
+        assertEquals(request, projected);
+    }
+
+    @Test
+    public void testDoesNotUnwrapOtherResourceWrappers() {
+        Resource testCase = new ResourceWrapper(resource);
+        Object projected = provider.getAdaptable(testCase, null);
+        assertEquals(testCase, projected);
+    }
+
+    @Test
+    public void testDoesNotUnwrapOtherRequestWrappers() {
+        SlingHttpServletRequest testCase = new SlingHttpServletRequestWrapper(request);
+        Object projected = provider.getAdaptable(testCase, null);
+        assertEquals(testCase, projected);
+    }
+}


### PR DESCRIPTION
This implements a `ViaProvider` that undoes the changes done by `ForceResourceType` and `ResourceSuperType`. 

This is in particular helpful if a model `A` refers to another model `B` using `@Self` and both models are extended using the delegation pattern. In such a case the original `AImpl` would use the wrapped request/resource of the `ResourceSuperTypeViaProvider` to obtain the model for `B` which would not take the extension of model `B` for a more specific resource type into account. 

This depends on the API changes in https://github.com/apache/sling-org-apache-sling-models-api/pull/3

For more details see the integration tests in https://github.com/apache/sling-org-apache-sling-models-integration-tests/pull/2/files