### PR TITLE
SLING-11074: cache model for all adapter types

### DIFF
--- a/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithMultipleAdapters.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithMultipleAdapters.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.testmodels.classes;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.testmodels.interfaces.CachedModelWithMultipleAdaptersA;
+import org.apache.sling.models.testmodels.interfaces.CachedModelWithMultipleAdaptersB;
+
+@Model(
+    adaptables = {SlingHttpServletRequest.class, Resource.class},
+    adapters = { CachedModelWithMultipleAdaptersA.class, CachedModelWithMultipleAdaptersB.class },
+    cache = true)
+public class CachedModelWithMultipleAdapters implements CachedModelWithMultipleAdaptersA, CachedModelWithMultipleAdaptersB {
+
+}

--- a/src/test/java/org/apache/sling/models/testmodels/interfaces/CachedModelWithMultipleAdaptersA.java
+++ b/src/test/java/org/apache/sling/models/testmodels/interfaces/CachedModelWithMultipleAdaptersA.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.testmodels.interfaces;
+
+public interface CachedModelWithMultipleAdaptersA {
+}

--- a/src/test/java/org/apache/sling/models/testmodels/interfaces/CachedModelWithMultipleAdaptersB.java
+++ b/src/test/java/org/apache/sling/models/testmodels/interfaces/CachedModelWithMultipleAdaptersB.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.testmodels.interfaces;
+
+public interface CachedModelWithMultipleAdaptersB {
+}


### PR DESCRIPTION
Cache a model for its adapter types in addition to the requested type. This may be useful if a model is referred to from various places by different interfaces. 