### PR TITLE
SLING-11073: rename OriginalResourceViaProvider to OriginalResourceTypeViaProvider

### DIFF
--- a/src/main/java/org/apache/sling/models/impl/via/OriginalResourceTypeViaProvider.java
+++ b/src/main/java/org/apache/sling/models/impl/via/OriginalResourceTypeViaProvider.java
@@ -19,26 +19,26 @@ package org.apache.sling.models.impl.via;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.ViaProviderType;
-import org.apache.sling.models.annotations.via.OriginalResource;
+import org.apache.sling.models.annotations.via.OriginalResourceType;
 import org.apache.sling.models.spi.ViaProvider;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * This {@link ViaProvider} implements the counterpart of the {@link ForcedResourceTypeViaProvider} and
+ * This {@link ViaProvider} implements the counterpart of the {@link ForcedResourceTypeViaProvider} and the
  * {@link ResourceSuperTypeViaProvider}. It is in particular helpful in models that want to inject another model using the original
- * {@link Resource}'s or {@link SlingHttpServletRequest}'s resource type instead of the one forced by either of the above-mentioned via
- * providers.
+ * {@link Resource}'s or {@link SlingHttpServletRequest}'s resource type instead of the one forced by either of the above-mentioned
+ * {@link ViaProvider}s
  * <p>
  * The implementation simply unwraps the {@link org.apache.sling.api.resource.ResourceWrapper} or
  * {@link org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper} used by the {@link ForcedResourceTypeViaProvider} and
  * {@link ResourceSuperTypeViaProvider}.
  */
 @Component
-public class OriginalResourceViaProvider implements ViaProvider {
+public class OriginalResourceTypeViaProvider implements ViaProvider {
 
     @Override
     public Class<? extends ViaProviderType> getType() {
-        return OriginalResource.class;
+        return OriginalResourceType.class;
     }
 
     @Override

--- a/src/test/java/org/apache/sling/models/impl/via/OriginalResourceTypeViaProviderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/via/OriginalResourceTypeViaProviderTest.java
@@ -20,7 +20,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceWrapper;
 import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
-import org.apache.sling.models.annotations.via.OriginalResource;
+import org.apache.sling.models.annotations.via.OriginalResourceType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -30,9 +30,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
-public class OriginalResourceViaProviderTest {
+public class OriginalResourceTypeViaProviderTest {
 
-    private OriginalResourceViaProvider provider = new OriginalResourceViaProvider();
+    private OriginalResourceTypeViaProvider provider = new OriginalResourceTypeViaProvider();
 
     @Mock
     private Resource resource;
@@ -42,7 +42,7 @@ public class OriginalResourceViaProviderTest {
 
     @Test
     public void testReturnsCorrectMarkerInterface() {
-        assertEquals(OriginalResource.class, provider.getType());
+        assertEquals(OriginalResourceType.class, provider.getType());
     }
 
     @Test


### PR DESCRIPTION
In order to make it clear that this is the counterpart of ResourceSuperTypeViaProvider and ForcedResourceTypeViaProvider.