### PR TITLE
SLING-11133: cache models by picked implementation type

### DIFF
--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -387,7 +387,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
 
             if (modelAnnotation.cache()) {
                 adaptableCache = getOrCreateCache(adaptable);
-                SoftReference<Object> softReference = adaptableCache.get(requestedType);
+                SoftReference<Object> softReference = adaptableCache.get(modelClass.getType());
                 if (softReference != null) {
                     ModelType cachedObject = (ModelType) softReference.get();
                     if (cachedObject != null) {
@@ -416,7 +416,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
                         ModelType model = (ModelType) Proxy.newProxyInstance(modelClass.getType().getClassLoader(), new Class<?>[] { modelClass.getType() }, handlerResult.getValue());
 
                         if (modelAnnotation.cache() && adaptableCache != null) {
-                            adaptableCache.put(requestedType, new SoftReference<Object>(model));
+                            adaptableCache.put(modelClass.getType(), new SoftReference<>(model));
                         }
 
                         result = new Result<>(model);
@@ -428,7 +428,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
                         result = createObject(adaptable, modelClass);
 
                         if (result.wasSuccessful() && modelAnnotation.cache() && adaptableCache != null) {
-                            adaptableCache.put(requestedType, new SoftReference<Object>(result.getValue()));
+                            adaptableCache.put(modelClass.getType(), new SoftReference<>(result.getValue()));
                         }
                     } catch (Exception e) {
                         String msg = String.format("Unable to create model %s", modelClass.getType());

--- a/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithAdapterTypes12.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithAdapterTypes12.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.testmodels.classes;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.testmodels.interfaces.AdapterType1;
+import org.apache.sling.models.testmodels.interfaces.AdapterType2;
+
+@Model(
+    adaptables = SlingHttpServletRequest.class,
+    adapters = { AdapterType1.class, AdapterType2.class },
+    cache = true
+)
+public class CachedModelWithAdapterTypes12 implements AdapterType1, AdapterType2 {
+
+
+}

--- a/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithAdapterTypes23.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithAdapterTypes23.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.testmodels.classes;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.testmodels.interfaces.AdapterType1;
+import org.apache.sling.models.testmodels.interfaces.AdapterType2;
+import org.apache.sling.models.testmodels.interfaces.AdapterType3;
+
+@Model(
+    adaptables = SlingHttpServletRequest.class,
+    adapters = { AdapterType2.class, AdapterType3.class },
+    cache = true
+)
+public class CachedModelWithAdapterTypes23 implements AdapterType2, AdapterType3 {
+
+
+}

--- a/src/test/java/org/apache/sling/models/testmodels/interfaces/AdapterType1.java
+++ b/src/test/java/org/apache/sling/models/testmodels/interfaces/AdapterType1.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.testmodels.interfaces;
+
+public interface AdapterType1 {
+}

--- a/src/test/java/org/apache/sling/models/testmodels/interfaces/AdapterType2.java
+++ b/src/test/java/org/apache/sling/models/testmodels/interfaces/AdapterType2.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.testmodels.interfaces;
+
+public interface AdapterType2 {
+}

--- a/src/test/java/org/apache/sling/models/testmodels/interfaces/AdapterType3.java
+++ b/src/test/java/org/apache/sling/models/testmodels/interfaces/AdapterType3.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.models.testmodels.interfaces;
+
+public interface AdapterType3 {
+}


### PR DESCRIPTION
Currently the model caching works with the requested type. This does not support models that are registered with multiple adapter types. For example a model `ModelA` that is registered with `AdapterType1` and `AdapterType2` should be cached after being adapted using `AdapterType1` and can be returned from cache if adapted using `AdapterType2`. 

```
interface AdapterType1 {}
interface AdapterType2 {}

@Model(adaptables = Resource.class, adapterType={AdapterType1.class, AdapterType2.class}, cache = true) 
class Model implements AdapterType1, AdapterType2 {}

assertSame(resource.adaptTo(Model.class), resouce.adaptTo(AdapterType1.class));
assertSame(resource.adaptTo(AdapterType1.class), resouce.adaptTo(AdapterType2.class));
```

With this change the models are cached with their implementation type as key, which preserves the existing behaviour but also supports the one described above. It should also behave as expected, when the implementation type for a given adapter type and adaptable changes during the lifetime of the cache, for example when a new implementation picker gets registered. 

@raducotescu any thoughts? I saw you reviewing a previous PR in this area. @kwin maybe any thoughts? 