### PR TITLE
SLING-11595 Add missing test case for AnnotationConflictsTest

### DIFF
--- a/src/test/java/org/apache/sling/models/impl/AnnotationConflictsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AnnotationConflictsTest.java
@@ -239,6 +239,28 @@ public class AnnotationConflictsTest {
         }
     }
 
+    // @Optional overrides REQUIRED strategy
+    @Model(adaptables = Resource.class)
+    public static class SuccessfulSingleOptionalBySeparateAnnotationOverridingStrategyFieldModel implements Methods {
+
+        @ValueMapValue
+        private String otherText;
+
+        @Override
+        public String getOtherText() {
+            return otherText;
+        }
+
+        @ValueMapValue(injectionStrategy = InjectionStrategy.REQUIRED)
+        @Optional
+        private String emptyText;
+
+        @Override
+        public String getEmptyText() {
+            return emptyText;
+        }
+    }
+
     private interface Methods {
         String getOtherText();
         String getEmptyText();


### PR DESCRIPTION
This test if similar to FailingSingleRequiredBySeparateAnnotationOverridingStrategyFieldModel but it tests the opposite case: `@Optional` overrides `injectionStrategy = REQUIRED`.

See also:
- https://issues.apache.org/jira/browse/SLING-11595