### PR TITLE
SLING-11890 Fix embed of org.apache.sling.scripting.core.impl.helper.ProtectedBindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.core</artifactId>
             <version>2.4.8</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
reverting scope to "compile" as it was set previously before applying SLING-11832, otherwise the artifact is not embedded by the shade plugin

https://issues.apache.org/jira/browse/SLING-11890