### PR TITLE
SLING-12374 : Improve injector handling in ModelAdapterFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.osgi</artifactId>
-            <version>2.4.0</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.util.converter</artifactId>
             <version>1.0.9</version>
@@ -146,12 +140,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.metrics</artifactId>
-            <version>1.2.12</version>
             <scope>provided</scope>
         </dependency>
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,12 @@
             <version>2.4.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.converter</artifactId>
+            <version>1.0.9</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Artifact is shaded and inlined, only some classes included (see above) -->
         <dependency>
             <groupId>org.apache.sling</groupId>
@@ -157,7 +163,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
-            <version>3.2.0</version>
+            <version>3.5.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -191,12 +197,6 @@
             <scope>test</scope>
         </dependency>
         <!-- for testing the annotations -->
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.util.converter</artifactId>
-            <version>1.0.9</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -60,18 +60,8 @@ final class AdapterImplementations {
     private final ConcurrentMap<Bundle, List<String>> resourceTypeRemovalListsForResources = new ConcurrentHashMap<>();
     private final ConcurrentMap<Bundle, List<String>> resourceTypeRemovalListsForRequests = new ConcurrentHashMap<>();
 
-    private volatile ImplementationPicker[] sortedImplementationPickers = new ImplementationPicker[0];
     private volatile StaticInjectAnnotationProcessorFactory[] sortedStaticInjectAnnotationProcessorFactories =
             new StaticInjectAnnotationProcessorFactory[0];
-
-    public void setImplementationPickers(Collection<ImplementationPicker> implementationPickers) {
-        this.sortedImplementationPickers =
-                implementationPickers.toArray(new ImplementationPicker[implementationPickers.size()]);
-    }
-
-    public ImplementationPicker[] getImplementationPickers() {
-        return this.sortedImplementationPickers;
-    }
 
     public StaticInjectAnnotationProcessorFactory[] getStaticInjectAnnotationProcessorFactories() {
         return sortedStaticInjectAnnotationProcessorFactories;
@@ -195,7 +185,10 @@ final class AdapterImplementations {
      * @return Implementation type or null if none detected
      */
     @SuppressWarnings("unchecked")
-    public <ModelType> ModelClass<ModelType> lookup(Class<ModelType> adapterType, Object adaptable) {
+    public <ModelType> ModelClass<ModelType> lookup(
+            Class<ModelType> adapterType,
+            Object adaptable,
+            final List<ImplementationPicker> sortedImplementationPickers) {
         String key = adapterType.getName();
 
         // lookup in cache for models without adapter classes
@@ -219,7 +212,7 @@ final class AdapterImplementations {
             implementationsArray[i] = implementationWrappersArray[i].getType();
         }
 
-        for (ImplementationPicker picker : this.sortedImplementationPickers) {
+        for (ImplementationPicker picker : sortedImplementationPickers) {
             Class<?> implementation = picker.pick(adapterType, implementationsArray, adaptable);
             if (implementation != null) {
                 for (int i = 0; i < implementationWrappersArray.length; i++) {

--- a/src/main/java/org/apache/sling/models/impl/DisposalCallbackRegistryImpl.java
+++ b/src/main/java/org/apache/sling/models/impl/DisposalCallbackRegistryImpl.java
@@ -18,25 +18,30 @@
  */
 package org.apache.sling.models.impl;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
-import org.osgi.framework.Constants;
+import org.apache.sling.models.spi.DisposalCallback;
+import org.apache.sling.models.spi.DisposalCallbackRegistry;
+import org.jetbrains.annotations.NotNull;
 
-@SuppressWarnings("serial")
-public class ServicePropertiesMap extends HashMap<String, Object> implements Comparable<ServicePropertiesMap> {
+public class DisposalCallbackRegistryImpl implements DisposalCallbackRegistry {
 
-    public ServicePropertiesMap(long serviceId, int serviceRanking) {
-        super();
-        put(Constants.SERVICE_ID, serviceId);
-        put(Constants.SERVICE_RANKING, serviceRanking);
-    }
+    List<DisposalCallback> callbacks = new ArrayList<>();
 
     @Override
-    public int compareTo(ServicePropertiesMap o) {
-        int result = ((Integer) get(Constants.SERVICE_RANKING)).compareTo((Integer) o.get(Constants.SERVICE_RANKING));
-        if (result == 0) {
-            result = ((Long) get(Constants.SERVICE_ID)).compareTo((Long) o.get(Constants.SERVICE_ID));
+    public void addDisposalCallback(@NotNull DisposalCallback callback) {
+        callbacks.add(callback);
+    }
+
+    void seal() {
+        callbacks = Collections.unmodifiableList(callbacks);
+    }
+
+    public void onDisposed() {
+        for (DisposalCallback callback : callbacks) {
+            callback.onDisposed();
         }
-        return result;
     }
 }

--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -52,7 +53,6 @@ import org.apache.sling.api.adapter.Adaptable;
 import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.commons.osgi.RankedServices;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.ValidationStrategy;
 import org.apache.sling.models.annotations.ViaProviderType;
@@ -77,7 +77,6 @@ import org.apache.sling.models.impl.model.ModelClass;
 import org.apache.sling.models.impl.model.ModelClassConstructor;
 import org.apache.sling.models.impl.model.OptionalTypedInjectableElement;
 import org.apache.sling.models.spi.AcceptsNullName;
-import org.apache.sling.models.spi.DisposalCallback;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
 import org.apache.sling.models.spi.ImplementationPicker;
 import org.apache.sling.models.spi.Injector;
@@ -100,6 +99,7 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -128,34 +128,11 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
 
     private static final String REQUEST_CACHE_ATTRIBUTE = ModelAdapterFactory.class.getName() + ".AdapterCache";
 
-    private static class DisposalCallbackRegistryImpl implements DisposalCallbackRegistry, Disposable {
-
-        private List<DisposalCallback> callbacks = new ArrayList<>();
-
-        @Override
-        public void addDisposalCallback(@NotNull DisposalCallback callback) {
-            callbacks.add(callback);
-        }
-
-        private void seal() {
-            callbacks = Collections.unmodifiableList(callbacks);
-        }
-
-        @Override
-        public void onDisposed() {
-            for (DisposalCallback callback : callbacks) {
-                callback.onDisposed();
-            }
-        }
-    }
-
-    private interface Disposable {
-        void onDisposed();
-    }
+    private final Logger log = LoggerFactory.getLogger(ModelAdapterFactory.class);
 
     private ReferenceQueue<Object> queue;
 
-    private ConcurrentMap<java.lang.ref.Reference<Object>, Disposable> disposalCallbacks;
+    private ConcurrentMap<java.lang.ref.Reference<Object>, DisposalCallbackRegistryImpl> disposalCallbacks;
 
     @Override
     public void run() {
@@ -166,16 +143,21 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         java.lang.ref.Reference<?> ref = queue.poll();
         while (ref != null) {
             log.debug("calling disposal for {}.", ref);
-            Disposable registry = disposalCallbacks.remove(ref);
-            registry.onDisposed();
+            final DisposalCallbackRegistryImpl registry = disposalCallbacks.remove(ref);
+            if (registry != null) {
+                registry.onDisposed();
+            }
             ref = queue.poll();
         }
     }
 
-    private static final Logger log = LoggerFactory.getLogger(ModelAdapterFactory.class);
+    /** Injectors are sorted by DS according to their service ranking */
+    @Reference(
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            fieldOption = FieldOption.REPLACE)
+    volatile List<Injector> injectors;
 
-    private final ConcurrentMap<String, RankedServices<Injector>> injectors = new ConcurrentHashMap<>();
-    private final RankedServices<Injector> sortedInjectors = new RankedServices<>();
     private final ConcurrentMap<Class<? extends ViaProviderType>, ViaProvider> viaProviders = new ConcurrentHashMap<>();
 
     @Reference(
@@ -192,14 +174,19 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
     volatile Collection<InjectAnnotationProcessorFactory2>
             injectAnnotationProcessorFactories2; // this must be non-final for fieldOption=replace!
 
-    private final RankedServices<StaticInjectAnnotationProcessorFactory> staticInjectAnnotationProcessorFactories =
-            new RankedServices<>();
+    private volatile Map<Comparable<?>, StaticInjectAnnotationProcessorFactory>
+            staticInjectAnnotationProcessorFactories = Collections.emptyMap();
 
-    private final RankedServices<ImplementationPicker> implementationPickers = new RankedServices<>();
+    /** Implementation pickers are sorted by DS according to their service ranking */
+    @Reference(
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            fieldOption = FieldOption.REPLACE)
+    volatile List<ImplementationPicker> implementationPickers;
 
     // bind the service with the highest priority (if a new one comes in this service gets restarted)
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
-    private ModelValidation modelValidation = null;
+    private ModelValidation modelValidation;
 
     @Reference(name = "modelExporter", cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     volatile Collection<ModelExporter> modelExporters; // this must be non-final for fieldOption=replace!
@@ -321,7 +308,8 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         // lookup ModelClass wrapper for implementation type
         // additionally check if a different implementation class was registered for this adapter type
         // the adapter implementation is initially filled by the ModelPackageBundleList
-        ModelClass<ModelType> modelClass = this.adapterImplementations.lookup(requestedType, adaptable);
+        ModelClass<ModelType> modelClass =
+                this.adapterImplementations.lookup(requestedType, adaptable, this.implementationPickers);
         if (modelClass != null) {
             log.debug("Using implementation type {} for requested adapter type {}", modelClass, requestedType);
             return modelClass;
@@ -581,20 +569,18 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         RuntimeException lastInjectionException = null;
         if (injectionAdaptable != null) {
 
-            // prepare the set of injectors to process. if a source is given only use injectors with this name.
-            final RankedServices<Injector> injectorsToProcess;
             if (StringUtils.isEmpty(source)) {
-                injectorsToProcess = sortedInjectors;
-            } else {
-                injectorsToProcess = injectors.get(source);
-                if (injectorsToProcess == null) {
-                    throw new IllegalArgumentException(
-                            "No Sling Models Injector registered for source '" + source + "'.");
-                }
+                source = null;
             }
-
             // find the right injector
-            for (Injector injector : injectorsToProcess) {
+            final List<Injector> localInjectors = this.injectors;
+            boolean foundSource = false;
+            for (final Injector injector : localInjectors) {
+                // if a source is given only use injectors with this name.
+                if (source != null && !source.equals(injector.getName())) {
+                    continue;
+                }
+                foundSource = true;
                 if (name != null || injector instanceof AcceptsNullName) {
                     Object preparedValue = injectionAdaptable;
 
@@ -631,6 +617,9 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
                         }
                     }
                 }
+            }
+            if (!foundSource && source != null) {
+                throw new IllegalArgumentException("No Sling Models Injector registered for source '" + source + "'.");
             }
         }
         // if injection failed, use default
@@ -1225,61 +1214,27 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
-    protected void bindInjector(final Injector injector, final Map<String, Object> props) {
-        RankedServices<Injector> newRankedServices = new RankedServices<>();
-        RankedServices<Injector> injectorsPerInjectorName =
-                injectors.putIfAbsent(injector.getName(), newRankedServices);
-        if (injectorsPerInjectorName == null) {
-            injectorsPerInjectorName = newRankedServices;
-        }
-        injectorsPerInjectorName.bind(injector, props);
-        sortedInjectors.bind(injector, props);
-    }
-
-    protected void unbindInjector(final Injector injector, final Map<String, Object> props) {
-        RankedServices<Injector> injectorsPerInjectorName = injectors.get(injector.getName());
-        if (injectorsPerInjectorName != null) {
-            injectorsPerInjectorName.unbind(injector, props);
-        }
-        sortedInjectors.unbind(injector, props);
-    }
-
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     protected void bindStaticInjectAnnotationProcessorFactory(
             final StaticInjectAnnotationProcessorFactory factory, final Map<String, Object> props) {
-        synchronized (staticInjectAnnotationProcessorFactories) {
-            staticInjectAnnotationProcessorFactories.bind(factory, props);
+        synchronized (this) {
+            final Map<Comparable<?>, StaticInjectAnnotationProcessorFactory> factoryMap =
+                    new TreeMap<>(this.staticInjectAnnotationProcessorFactories);
+            factoryMap.put((Comparable<?>) props, factory);
+            this.staticInjectAnnotationProcessorFactories = factoryMap;
             this.adapterImplementations.setStaticInjectAnnotationProcessorFactories(
-                    staticInjectAnnotationProcessorFactories.get());
+                    staticInjectAnnotationProcessorFactories.values());
         }
     }
 
     protected void unbindStaticInjectAnnotationProcessorFactory(
             final StaticInjectAnnotationProcessorFactory factory, final Map<String, Object> props) {
-        synchronized (staticInjectAnnotationProcessorFactories) {
-            staticInjectAnnotationProcessorFactories.unbind(factory, props);
+        synchronized (this) {
+            final Map<Comparable<?>, StaticInjectAnnotationProcessorFactory> factoryMap =
+                    new TreeMap<>(this.staticInjectAnnotationProcessorFactories);
+            factoryMap.remove((Comparable<?>) props);
+            this.staticInjectAnnotationProcessorFactories = factoryMap;
             this.adapterImplementations.setStaticInjectAnnotationProcessorFactories(
-                    staticInjectAnnotationProcessorFactories.get());
-        }
-    }
-
-    @Reference(
-            name = "implementationPicker",
-            cardinality = ReferenceCardinality.MULTIPLE,
-            policy = ReferencePolicy.DYNAMIC)
-    protected void bindImplementationPicker(
-            final ImplementationPicker implementationPicker, final Map<String, Object> props) {
-        synchronized (implementationPickers) {
-            implementationPickers.bind(implementationPicker, props);
-            this.adapterImplementations.setImplementationPickers(implementationPickers.get());
-        }
-    }
-
-    protected void unbindImplementationPicker(
-            final ImplementationPicker implementationPicker, final Map<String, Object> props) {
-        synchronized (implementationPickers) {
-            implementationPickers.unbind(implementationPicker, props);
-            this.adapterImplementations.setImplementationPickers(implementationPickers.get());
+                    staticInjectAnnotationProcessorFactories.values());
         }
     }
 
@@ -1296,7 +1251,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
 
     @NotNull
     Collection<Injector> getInjectors() {
-        return sortedInjectors.get();
+        return injectors;
     }
 
     @NotNull
@@ -1311,12 +1266,14 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
 
     @NotNull
     Collection<StaticInjectAnnotationProcessorFactory> getStaticInjectAnnotationProcessorFactories() {
-        return staticInjectAnnotationProcessorFactories.get();
+        synchronized (this) {
+            return new ArrayList<>(staticInjectAnnotationProcessorFactories.values());
+        }
     }
 
     @NotNull
-    ImplementationPicker[] getImplementationPickers() {
-        return adapterImplementations.getImplementationPickers();
+    List<ImplementationPicker> getImplementationPickers() {
+        return this.implementationPickers;
     }
 
     @NotNull
@@ -1425,8 +1382,8 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
             if (list instanceof List) {
                 final List<?> callbackList = (List<?>) list;
                 for (final Object disposable : callbackList) {
-                    if (disposable instanceof Disposable) {
-                        ((Disposable) disposable).onDisposed();
+                    if (disposable instanceof DisposalCallbackRegistryImpl) {
+                        ((DisposalCallbackRegistryImpl) disposable).onDisposed();
                     }
                 }
                 callbackList.clear();
@@ -1449,7 +1406,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
             if (adaptable instanceof SlingHttpServletRequest) {
                 final Object list = ((SlingHttpServletRequest) adaptable).getAttribute(REQUEST_MARKER_ATTRIBUTE);
                 if (list instanceof List) {
-                    ((List<Disposable>) list).add(registry);
+                    ((List<DisposalCallbackRegistryImpl>) list).add(registry);
                     registered = true;
                 }
             }

--- a/src/main/java/org/apache/sling/models/impl/ModelConfigurationPrinter.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelConfigurationPrinter.java
@@ -22,6 +22,7 @@ import javax.servlet.Servlet;
 
 import java.io.PrintWriter;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.sling.models.annotations.ViaProviderType;
@@ -98,8 +99,8 @@ public class ModelConfigurationPrinter {
 
         // implementation pickers
         printWriter.println("Sling Models Implementation Pickers:");
-        ImplementationPicker[] pickers = modelAdapterFactory.getImplementationPickers();
-        if (pickers == null || pickers.length == 0) {
+        List<ImplementationPicker> pickers = modelAdapterFactory.getImplementationPickers();
+        if (pickers.size() == 0) {
             printWriter.println("none");
         } else {
             for (ImplementationPicker picker : pickers) {

--- a/src/test/java/org/apache/sling/models/impl/AdapterFactoryTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterFactoryTest.java
@@ -86,14 +86,15 @@ public class AdapterFactoryTest {
         factory.activate(componentCtx, config);
         factory.injectAnnotationProcessorFactories = Collections.emptyList();
         factory.injectAnnotationProcessorFactories2 = Collections.emptyList();
+        factory.injectors = Collections.emptyList();
+        factory.implementationPickers = Collections.emptyList();
         return factory;
     }
 
     @Before
     public void setup() {
         factory = createModelAdapterFactory();
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(0, 0));
-        factory.bindInjector(new SelfInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new ValueMapInjector(), new SelfInjector());
         factory.modelExporters = Arrays.<ModelExporter>asList(
                 new FirstStringExporter(), new SecondStringExporter(), new FirstIntegerExporter());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -61,12 +61,11 @@ public class AdapterImplementationsTest {
     @Before
     public void setUp() {
         underTest = new AdapterImplementations();
-        underTest.setImplementationPickers(Arrays.asList(new ImplementationPicker[] {new FirstImplementationPicker()}));
     }
 
     @Test
     public void testNoMapping() {
-        assertNull(underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE));
+        assertNull(underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE, Arrays.asList(new FirstImplementationPicker())));
 
         // make sure this raises no exception
         underTest.remove(SAMPLE_ADAPTER.getName(), String.class.getName());
@@ -77,11 +76,14 @@ public class AdapterImplementationsTest {
         underTest.addAll(String.class, SAMPLE_ADAPTER);
 
         assertEquals(
-                String.class, underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE).getType());
+                String.class,
+                underTest
+                        .lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE, Arrays.asList(new FirstImplementationPicker()))
+                        .getType());
 
         underTest.remove(SAMPLE_ADAPTER.getName(), String.class.getName());
 
-        assertNull(underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE));
+        assertNull(underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE, Arrays.asList(new FirstImplementationPicker())));
     }
 
     @Test
@@ -92,17 +94,22 @@ public class AdapterImplementationsTest {
 
         assertEquals(
                 Integer.class,
-                underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE).getType());
+                underTest
+                        .lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE, Arrays.asList(new FirstImplementationPicker()))
+                        .getType());
 
         underTest.remove(SAMPLE_ADAPTER.getName(), Integer.class.getName());
 
         assertEquals(
-                Long.class, underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE).getType());
+                Long.class,
+                underTest
+                        .lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE, Arrays.asList(new FirstImplementationPicker()))
+                        .getType());
 
         underTest.remove(SAMPLE_ADAPTER.getName(), Long.class.getName());
         underTest.remove(SAMPLE_ADAPTER.getName(), String.class.getName());
 
-        assertNull(underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE));
+        assertNull(underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE, Arrays.asList(new FirstImplementationPicker())));
     }
 
     @Test
@@ -113,20 +120,26 @@ public class AdapterImplementationsTest {
 
         underTest.removeAll();
 
-        assertNull(underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE));
+        assertNull(underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE, Arrays.asList(new FirstImplementationPicker())));
     }
 
     @Test
     public void testMultipleImplementationPickers() {
-        underTest.setImplementationPickers(Arrays.asList(
-                new NoneImplementationPicker(), new LastImplementationPicker(), new FirstImplementationPicker()));
-
         underTest.addAll(String.class, SAMPLE_ADAPTER);
         underTest.addAll(Integer.class, SAMPLE_ADAPTER);
         underTest.addAll(Long.class, SAMPLE_ADAPTER);
 
         assertEquals(
-                String.class, underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE).getType());
+                String.class,
+                underTest
+                        .lookup(
+                                SAMPLE_ADAPTER,
+                                SAMPLE_ADAPTABLE,
+                                Arrays.asList(
+                                        new NoneImplementationPicker(),
+                                        new LastImplementationPicker(),
+                                        new FirstImplementationPicker()))
+                        .getType());
     }
 
     @Test
@@ -135,7 +148,9 @@ public class AdapterImplementationsTest {
 
         assertEquals(
                 SAMPLE_ADAPTER,
-                underTest.lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE).getType());
+                underTest
+                        .lookup(SAMPLE_ADAPTER, SAMPLE_ADAPTABLE, Arrays.asList(new FirstImplementationPicker()))
+                        .getType());
     }
 
     @Test

--- a/src/test/java/org/apache/sling/models/impl/AnnotationConflictsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AnnotationConflictsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.apache.sling.api.resource.Resource;
@@ -58,7 +59,7 @@ public class AnnotationConflictsTest {
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
         ValueMapInjector injector = new ValueMapInjector();
-        factory.bindInjector(injector, new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(injector);
         factory.injectAnnotationProcessorFactories =
                 Collections.<InjectAnnotationProcessorFactory>singletonList(new ValueMapInjector());
 

--- a/src/test/java/org/apache/sling/models/impl/CachingTest.java
+++ b/src/test/java/org/apache/sling/models/impl/CachingTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 
@@ -65,8 +66,7 @@ public class CachingTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new RequestAttributeInjector(), new ServicePropertiesMap(0, 0));
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new RequestAttributeInjector(), new ValueMapInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(
                 CachedModel.class,
                 UncachedModel.class,
@@ -205,17 +205,15 @@ public class CachingTest {
         // test 2 model implementations that share a common adapter type, with an implementation picker that selects
         // exactly one of the
         // implementations for the common adapter type. verify that the models are cached accordingly
-        factory.bindImplementationPicker(
-                (adapterType, impls, adaptable) -> {
-                    if (AdapterType1.class.equals(adapterType)) {
-                        return CachedModelWithAdapterTypes12.class;
-                    } else if (AdapterType2.class.equals(adapterType) || AdapterType3.class.equals(adapterType)) {
-                        return CachedModelWithAdapterTypes23.class;
-                    } else {
-                        return null;
-                    }
-                },
-                new ServicePropertiesMap(2, 0));
+        factory.implementationPickers = Collections.singletonList((adapterType, impls, adaptable) -> {
+            if (AdapterType1.class.equals(adapterType)) {
+                return CachedModelWithAdapterTypes12.class;
+            } else if (AdapterType2.class.equals(adapterType) || AdapterType3.class.equals(adapterType)) {
+                return CachedModelWithAdapterTypes23.class;
+            } else {
+                return null;
+            }
+        });
 
         CachedModelWithAdapterTypes12 byImpl12 = factory.getAdapter(request, CachedModelWithAdapterTypes12.class);
         CachedModelWithAdapterTypes23 byImpl23 = factory.getAdapter(request, CachedModelWithAdapterTypes23.class);

--- a/src/test/java/org/apache/sling/models/impl/ConstructorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ConstructorTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.models.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -75,8 +76,7 @@ public class ConstructorTest {
         when(request.getAttribute("attribute2")).thenReturn(STRING_VALUE);
 
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new RequestAttributeInjector(), new ServicePropertiesMap(1, 1));
-        factory.bindInjector(new SelfInjector(), new ServicePropertiesMap(2, 2));
+        factory.injectors = Arrays.asList(new RequestAttributeInjector(), new SelfInjector());
         factory.bindViaProvider(new BeanPropertyViaProvider(), null);
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(
                 WithOneConstructorModel.class,

--- a/src/test/java/org/apache/sling/models/impl/ConstructorVisibilityTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ConstructorVisibilityTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Arrays;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.impl.injectors.RequestAttributeInjector;
 import org.apache.sling.models.impl.injectors.SelfInjector;
@@ -42,8 +44,7 @@ public class ConstructorVisibilityTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new RequestAttributeInjector(), new ServicePropertiesMap(1, 1));
-        factory.bindInjector(new SelfInjector(), new ServicePropertiesMap(2, 2));
+        factory.injectors = Arrays.asList(new RequestAttributeInjector(), new SelfInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(
                 ProtectedConstructorModel.class, PackagePrivateConstructorModel.class, PrivateConstructorModel.class);
     }

--- a/src/test/java/org/apache/sling/models/impl/CustomInjectorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/CustomInjectorTest.java
@@ -20,6 +20,7 @@ package org.apache.sling.models.impl;
 
 import javax.inject.Inject;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.apache.sling.models.annotations.Model;
@@ -50,7 +51,7 @@ public class CustomInjectorTest {
 
     @Test
     public void testInjectorWhichDoesNotImplementAnnotationProcessor() {
-        factory.bindInjector(new SimpleInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new SimpleInjector());
 
         TestModel model = factory.getAdapter(new Object(), TestModel.class);
         assertNotNull(model);
@@ -61,8 +62,7 @@ public class CustomInjectorTest {
     public void testInjectorWithCustomAnnotation() {
         CustomAnnotationInjector injector = new CustomAnnotationInjector();
 
-        factory.bindInjector(new SimpleInjector(), new ServicePropertiesMap(1, 1));
-        factory.bindInjector(injector, new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new SimpleInjector(), injector);
         factory.injectAnnotationProcessorFactories = factory.injectAnnotationProcessorFactories =
                 Collections.<InjectAnnotationProcessorFactory>singletonList(injector);
 

--- a/src/test/java/org/apache/sling/models/impl/DefaultInterfaceMethodTest.java
+++ b/src/test/java/org/apache/sling/models/impl/DefaultInterfaceMethodTest.java
@@ -40,7 +40,7 @@ public class DefaultInterfaceMethodTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(0, 0));
+        factory.injectors = Collections.singletonList(new ValueMapInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(ModelWithDefaultMethods.class);
     }
 

--- a/src/test/java/org/apache/sling/models/impl/DefaultTest.java
+++ b/src/test/java/org/apache/sling/models/impl/DefaultTest.java
@@ -50,7 +50,8 @@ public class DefaultTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(0, 0));
+        factory.injectors = Arrays.asList(new ValueMapInjector());
+        factory.implementationPickers = Collections.emptyList();
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(
                 DefaultStringModel.class,
                 PropertyModelWithDefaults.class,

--- a/src/test/java/org/apache/sling/models/impl/ImplementsExtendsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ImplementsExtendsTest.java
@@ -20,6 +20,8 @@ package org.apache.sling.models.impl;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -83,8 +85,6 @@ public class ImplementsExtendsTest {
 
     private ImplementationPicker firstImplementationPicker = new FirstImplementationPicker();
 
-    private ServicePropertiesMap firstImplementationPickerProps = new ServicePropertiesMap(3, Integer.MAX_VALUE);
-
     @SuppressWarnings("unchecked")
     @Before
     public void setup() throws ClassNotFoundException, MalformedURLException {
@@ -109,8 +109,8 @@ public class ImplementsExtendsTest {
                 });
 
         factory = AdapterFactoryTest.createModelAdapterFactory(bundleContext);
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(2, 2));
-        factory.bindImplementationPicker(firstImplementationPicker, firstImplementationPickerProps);
+        factory.injectors = Collections.singletonList(new ValueMapInjector());
+        factory.implementationPickers = Collections.singletonList(firstImplementationPicker);
 
         // simulate bundle add for ModelPackageBundleListener
         Dictionary<String, String> headers = new Hashtable<String, String>();
@@ -178,7 +178,7 @@ public class ImplementsExtendsTest {
      */
     @Test
     public void testImplementsNoPickerWithAdapterEqualsImplementation() {
-        factory.unbindImplementationPicker(firstImplementationPicker, firstImplementationPickerProps);
+        factory.implementationPickers = Collections.emptyList();
 
         Resource res = getMockResourceWithProps();
 
@@ -194,7 +194,7 @@ public class ImplementsExtendsTest {
      */
     @Test(expected = ModelClassException.class)
     public void testImplementsNoPickerWithDifferentImplementations() {
-        factory.unbindImplementationPicker(firstImplementationPicker, firstImplementationPickerProps);
+        factory.implementationPickers = Collections.emptyList();
 
         Resource res = getMockResourceWithProps();
         factory.getAdapter(res, SampleServiceInterface.class);
@@ -247,8 +247,8 @@ public class ImplementsExtendsTest {
      */
     @Test
     public void testImplementsInterfaceModelWithPickLastImplementationPicker() {
-        factory.bindImplementationPicker(
-                new AdapterImplementationsTest.LastImplementationPicker(), new ServicePropertiesMap(3, 1));
+        factory.implementationPickers =
+                Arrays.asList(new AdapterImplementationsTest.LastImplementationPicker(), firstImplementationPicker);
 
         Resource res = getMockResourceWithProps();
         SampleServiceInterface model = factory.getAdapter(res, SampleServiceInterface.class);

--- a/src/test/java/org/apache/sling/models/impl/InjectorSpecificAnnotationTest.java
+++ b/src/test/java/org/apache/sling/models/impl/InjectorSpecificAnnotationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +45,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
@@ -84,23 +84,16 @@ public class InjectorSpecificAnnotationTest {
         ChildResourceInjector childResourceInjector = new ChildResourceInjector();
         RequestAttributeInjector requestAttributeInjector = new RequestAttributeInjector();
 
-        factory.bindInjector(bindingsInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 1L));
-        factory.bindInjector(valueMapInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 2L));
-        factory.bindInjector(childResourceInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 3L));
-        factory.bindInjector(
-                requestAttributeInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 4L));
-        factory.bindInjector(osgiInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 5L));
+        factory.injectors = Arrays.asList(
+                bindingsInjector, valueMapInjector, childResourceInjector, requestAttributeInjector, osgiInjector);
 
-        factory.bindStaticInjectAnnotationProcessorFactory(
-                bindingsInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 1L));
+        factory.bindStaticInjectAnnotationProcessorFactory(bindingsInjector, new ServicePropertiesMap(1L, 0));
         factory.injectAnnotationProcessorFactories =
                 Collections.<InjectAnnotationProcessorFactory>singletonList(valueMapInjector);
         factory.injectAnnotationProcessorFactories2 =
                 Collections.<InjectAnnotationProcessorFactory2>singletonList(childResourceInjector);
-        factory.bindStaticInjectAnnotationProcessorFactory(
-                requestAttributeInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 4L));
-        factory.bindStaticInjectAnnotationProcessorFactory(
-                osgiInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 5L));
+        factory.bindStaticInjectAnnotationProcessorFactory(requestAttributeInjector, new ServicePropertiesMap(4L, 0));
+        factory.bindStaticInjectAnnotationProcessorFactory(osgiInjector, new ServicePropertiesMap(5L, 0));
         factory.bindViaProvider(new BeanPropertyViaProvider(), null);
 
         SlingBindings bindings = new SlingBindings();

--- a/src/test/java/org/apache/sling/models/impl/InterfaceInheritanceTest.java
+++ b/src/test/java/org/apache/sling/models/impl/InterfaceInheritanceTest.java
@@ -49,7 +49,7 @@ public class InterfaceInheritanceTest {
 
         factory = AdapterFactoryTest.createModelAdapterFactory();
         ValueMapInjector valueMapInjector = new ValueMapInjector();
-        factory.bindInjector(valueMapInjector, new ServicePropertiesMap(1, 2));
+        factory.injectors = Collections.singletonList(valueMapInjector);
 
         factory.injectAnnotationProcessorFactories =
                 Collections.<InjectAnnotationProcessorFactory>singletonList(valueMapInjector);

--- a/src/test/java/org/apache/sling/models/impl/InvalidAdaptationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/InvalidAdaptationsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -46,8 +47,7 @@ public class InvalidAdaptationsTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(1, 1));
-        factory.bindInjector(new ChildResourceInjector(), new ServicePropertiesMap(2, 0));
+        factory.injectors = Arrays.asList(new ValueMapInjector(), new ChildResourceInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(NonModel.class, RequestModel.class);
     }
 

--- a/src/test/java/org/apache/sling/models/impl/MultipleInjectorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/MultipleInjectorTest.java
@@ -20,6 +20,8 @@ package org.apache.sling.models.impl;
 
 import javax.inject.Inject;
 
+import java.util.Arrays;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.models.annotations.Model;
@@ -62,8 +64,7 @@ public class MultipleInjectorTest {
 
         factory = AdapterFactoryTest.createModelAdapterFactory();
         // binding injector should be asked first as it has a lower service ranking!
-        factory.bindInjector(bindingsInjector, new ServicePropertiesMap(1, 1));
-        factory.bindInjector(attributesInjector, new ServicePropertiesMap(2, 2));
+        factory.injectors = Arrays.asList(bindingsInjector, attributesInjector);
         factory.bindStaticInjectAnnotationProcessorFactory(bindingsInjector, new ServicePropertiesMap(1, 1));
 
         when(request.getAttribute(SlingBindings.class.getName())).thenReturn(bindings);

--- a/src/test/java/org/apache/sling/models/impl/OSGiInjectionTest.java
+++ b/src/test/java/org/apache/sling/models/impl/OSGiInjectionTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.models.impl;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Dictionary;
 
 import org.apache.sling.api.resource.Resource;
@@ -74,7 +75,7 @@ public class OSGiInjectionTest {
 
         OSGiServiceInjector injectorFactory = new OSGiServiceInjector();
         injectorFactory.activate(bundleContext);
-        factory.bindInjector(injectorFactory, new ServicePropertiesMap(1, 1));
+        factory.injectors = Collections.singletonList(injectorFactory);
 
         bindings.setSling(helper);
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(

--- a/src/test/java/org/apache/sling/models/impl/OptionalObjectsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/OptionalObjectsTest.java
@@ -38,7 +38,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
@@ -76,23 +75,16 @@ public class OptionalObjectsTest {
         ChildResourceInjector childResourceInjector = new ChildResourceInjector();
         RequestAttributeInjector requestAttributeInjector = new RequestAttributeInjector();
 
-        factory.bindInjector(bindingsInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 1L));
-        factory.bindInjector(valueMapInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 2L));
-        factory.bindInjector(childResourceInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 3L));
-        factory.bindInjector(
-                requestAttributeInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 4L));
-        factory.bindInjector(osgiInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 5L));
+        factory.injectors = Arrays.asList(
+                bindingsInjector, valueMapInjector, childResourceInjector, requestAttributeInjector, osgiInjector);
 
-        factory.bindStaticInjectAnnotationProcessorFactory(
-                bindingsInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 1L));
+        factory.bindStaticInjectAnnotationProcessorFactory(bindingsInjector, new ServicePropertiesMap(1L, 0));
         factory.injectAnnotationProcessorFactories =
                 Collections.<InjectAnnotationProcessorFactory>singletonList(valueMapInjector);
         factory.injectAnnotationProcessorFactories2 =
                 Collections.<InjectAnnotationProcessorFactory2>singletonList(childResourceInjector);
-        factory.bindStaticInjectAnnotationProcessorFactory(
-                requestAttributeInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 4L));
-        factory.bindStaticInjectAnnotationProcessorFactory(
-                osgiInjector, Collections.<String, Object>singletonMap(Constants.SERVICE_ID, 5L));
+        factory.bindStaticInjectAnnotationProcessorFactory(requestAttributeInjector, new ServicePropertiesMap(4L, 0));
+        factory.bindStaticInjectAnnotationProcessorFactory(osgiInjector, new ServicePropertiesMap(5L, 0));
         factory.bindViaProvider(new BeanPropertyViaProvider(), null);
 
         SlingBindings bindings = new SlingBindings();

--- a/src/test/java/org/apache/sling/models/impl/OptionalPrimitivesTest.java
+++ b/src/test/java/org/apache/sling/models/impl/OptionalPrimitivesTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Arrays;
+
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.impl.injectors.ChildResourceInjector;
@@ -45,8 +47,7 @@ public class OptionalPrimitivesTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(2, 2));
-        factory.bindInjector(new ChildResourceInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new ChildResourceInjector(), new ValueMapInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(
                 org.apache.sling.models.testmodels.classes.OptionalPrimitivesModel.class,
                 org.apache.sling.models.testmodels.interfaces.OptionalPrimitivesModel.class,

--- a/src/test/java/org/apache/sling/models/impl/ParameterizedTypeFromRequestAttributeTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ParameterizedTypeFromRequestAttributeTest.java
@@ -49,7 +49,7 @@ public class ParameterizedTypeFromRequestAttributeTest {
         factory = AdapterFactoryTest.createModelAdapterFactory();
 
         RequestAttributeInjector injector = new RequestAttributeInjector();
-        factory.bindInjector(injector, new ServicePropertiesMap(1, 1));
+        factory.injectors = Collections.singletonList(injector);
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(TestModel.class);
     }
 

--- a/src/test/java/org/apache/sling/models/impl/RequestDisposalTest.java
+++ b/src/test/java/org/apache/sling/models/impl/RequestDisposalTest.java
@@ -24,6 +24,7 @@ import javax.servlet.ServletRequestEvent;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -71,7 +72,7 @@ public class RequestDisposalTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new DisposedInjector(), new ServicePropertiesMap(0, 0));
+        factory.injectors = Arrays.asList(new DisposedInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(TestModel.class);
 
         final Map<String, Object> attributes = new HashMap<>();

--- a/src/test/java/org/apache/sling/models/impl/RequestInjectionTest.java
+++ b/src/test/java/org/apache/sling/models/impl/RequestInjectionTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Arrays;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
@@ -55,7 +57,7 @@ public class RequestInjectionTest {
         when(request.getAttribute(SlingBindings.class.getName())).thenReturn(bindings);
 
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new BindingsInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new BindingsInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(
                 BindingsModel.class,
                 org.apache.sling.models.testmodels.classes.constructorinjection.BindingsModel.class);

--- a/src/test/java/org/apache/sling/models/impl/ResourceModelClassesTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ResourceModelClassesTest.java
@@ -72,8 +72,7 @@ public class ResourceModelClassesTest {
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
         ValueMapInjector valueMapInjector = new ValueMapInjector();
-        factory.bindInjector(valueMapInjector, new ServicePropertiesMap(2, 2));
-        factory.bindInjector(new ChildResourceInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new ChildResourceInjector(), valueMapInjector);
 
         factory.injectAnnotationProcessorFactories = factory.injectAnnotationProcessorFactories =
                 Collections.<InjectAnnotationProcessorFactory>singletonList(new ValueMapInjector());

--- a/src/test/java/org/apache/sling/models/impl/ResourceModelConstructorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ResourceModelConstructorTest.java
@@ -49,8 +49,7 @@ public class ResourceModelConstructorTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(2, 2));
-        factory.bindInjector(new ChildResourceInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new ChildResourceInjector(), new ValueMapInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(ParentModel.class, ChildModel.class);
     }
 

--- a/src/test/java/org/apache/sling/models/impl/ResourceModelInterfacesTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ResourceModelInterfacesTest.java
@@ -61,8 +61,7 @@ public class ResourceModelInterfacesTest {
     @Before
     public void setup() {
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(2, 2));
-        factory.bindInjector(new ChildResourceInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Arrays.asList(new ChildResourceInjector(), new ValueMapInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(
                 SimplePropertyModel.class,
                 ResourceModelWithRequiredField.class,

--- a/src/test/java/org/apache/sling/models/impl/ResourcePathInjectionTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ResourcePathInjectionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,9 +104,7 @@ public class ResourcePathInjectionTest {
         when(adaptableRequest.getResourceResolver()).thenReturn(resourceResolver);
 
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new SelfInjector(), new ServicePropertiesMap(1, Integer.MAX_VALUE));
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(2, 2000));
-        factory.bindInjector(new ResourcePathInjector(), new ServicePropertiesMap(3, 2500));
+        factory.injectors = Arrays.asList(new SelfInjector(), new ValueMapInjector(), new ResourcePathInjector());
         factory.bindStaticInjectAnnotationProcessorFactory(
                 new ResourcePathInjector(), new ServicePropertiesMap(3, 2500));
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(

--- a/src/test/java/org/apache/sling/models/impl/SelfDependencyTest.java
+++ b/src/test/java/org/apache/sling/models/impl/SelfDependencyTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.models.impl;
 
+import java.util.Collections;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.impl.injectors.SelfInjector;
 import org.apache.sling.models.testmodels.classes.DirectCyclicSelfDependencyModel;
@@ -59,7 +61,7 @@ public class SelfDependencyTest {
         });
 
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new SelfInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Collections.singletonList(new SelfInjector());
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(
                 SelfDependencyModelA.class,
                 SelfDependencyModelB.class,

--- a/src/test/java/org/apache/sling/models/impl/StaticInjectionAPFLoadOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/StaticInjectionAPFLoadOrderTest.java
@@ -21,7 +21,6 @@ package org.apache.sling.models.impl;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.commons.metrics.MetricsService;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
@@ -34,7 +33,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
@@ -126,7 +124,6 @@ public class StaticInjectionAPFLoadOrderTest {
     private void registerServices() {
         context.registerService(BindingsValuesProvidersByContext.class, bindingsValuesProvidersByContext);
         context.registerService(AdapterManager.class, adapterManager);
-        context.registerService(MetricsService.class, Mockito.mock(MetricsService.class));
         factory = context.registerInjectActivateService(new ModelAdapterFactory());
     }
 

--- a/src/test/java/org/apache/sling/models/impl/StaticInjectionAPFLoadOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/StaticInjectionAPFLoadOrderTest.java
@@ -131,7 +131,7 @@ public class StaticInjectionAPFLoadOrderTest {
     }
 
     private void registerCustomInjector() {
-        context.registerInjectActivateService(new SlingObjectInjector());
+        context.registerInjectActivateService(new SlingObjectInjector(), new ServicePropertiesMap(0, 0));
     }
 
     private void registerModel() {

--- a/src/test/java/org/apache/sling/models/impl/ViaTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ViaTest.java
@@ -59,7 +59,7 @@ public class ViaTest {
         when(request.getResource()).thenReturn(resource);
         when(resource.getChild("jcr:content")).thenReturn(childResource);
         factory = AdapterFactoryTest.createModelAdapterFactory();
-        factory.bindInjector(new ValueMapInjector(), new ServicePropertiesMap(1, 1));
+        factory.injectors = Collections.singletonList(new ValueMapInjector());
         factory.bindViaProvider(new BeanPropertyViaProvider(), null);
         factory.bindViaProvider(new ChildResourceViaProvider(), null);
         factory.adapterImplementations.addClassesAsAdapterAndImplementation(ViaModel.class);


### PR DESCRIPTION
We can leverage directly the features from Declarative Services which passes in collections of references already sorted by service ranking. In addition with leveraging that maps passed into bind methods are comparable, we can remove the usage of sling.commons.osgi.
With this we make the code a little bit simpler.