### PR TITLE
SLING-12472 Sling Models Impl: Implementation Picker service ranking is inversed

### DIFF
--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -212,7 +212,11 @@ final class AdapterImplementations {
             implementationsArray[i] = implementationWrappersArray[i].getType();
         }
 
-        for (ImplementationPicker picker : sortedImplementationPickers) {
+        // find first-matching implementation (look in service ranking REVERSE order)
+        ImplementationPicker[] localPickers =
+                sortedImplementationPickers.toArray(new ImplementationPicker[sortedImplementationPickers.size()]);
+        for (int pickerIndex = localPickers.length - 1; pickerIndex >= 0; pickerIndex--) {
+            ImplementationPicker picker = localPickers[pickerIndex];
             Class<?> implementation = picker.pick(adapterType, implementationsArray, adaptable);
             if (implementation != null) {
                 for (int i = 0; i < implementationWrappersArray.length; i++) {

--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -572,10 +572,12 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
             if (StringUtils.isEmpty(source)) {
                 source = null;
             }
-            // find the right injector
-            final List<Injector> localInjectors = this.injectors;
+            // find the right injector (look in service ranking REVERSE order)
+            final Injector[] localInjectors = this.injectors.toArray(new Injector[this.injectors.size()]);
             boolean foundSource = false;
-            for (final Injector injector : localInjectors) {
+            for (int injectorIndex = localInjectors.length - 1; injectorIndex >= 0; injectorIndex--) {
+                final Injector injector = localInjectors[injectorIndex];
+
                 // if a source is given only use injectors with this name.
                 if (source != null && !source.equals(injector.getName())) {
                     continue;
@@ -1231,7 +1233,7 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
         synchronized (this) {
             final Map<Comparable<?>, StaticInjectAnnotationProcessorFactory> factoryMap =
                     new TreeMap<>(this.staticInjectAnnotationProcessorFactories);
-            factoryMap.remove((Comparable<?>) props);
+            factoryMap.remove(props);
             this.staticInjectAnnotationProcessorFactories = factoryMap;
             this.adapterImplementations.setStaticInjectAnnotationProcessorFactories(
                     staticInjectAnnotationProcessorFactories.values());

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -136,9 +136,9 @@ public class AdapterImplementationsTest {
                                 SAMPLE_ADAPTER,
                                 SAMPLE_ADAPTABLE,
                                 Arrays.asList(
-                                        new NoneImplementationPicker(),
+                                        new FirstImplementationPicker(),
                                         new LastImplementationPicker(),
-                                        new FirstImplementationPicker()))
+                                        new NoneImplementationPicker()))
                         .getType());
     }
 

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementations_ImplementationPickerOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementations_ImplementationPickerOrderTest.java
@@ -66,7 +66,6 @@ public class AdapterImplementations_ImplementationPickerOrderTest {
 
     @Test
     public void testFirstImplementationPicker() {
-        // LastImplementationPicker has higher priority
         context.registerInjectActivateService(FirstImplementationPicker.class);
 
         IntSupplier result = factory.createModel(request, IntSupplier.class);

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementations_ImplementationPickerOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementations_ImplementationPickerOrderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.impl;
+
+import java.util.function.IntSupplier;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.adapter.AdapterManager;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.spi.ImplementationPicker;
+import org.apache.sling.models.testutil.ModelAdapterFactoryUtil;
+import org.apache.sling.scripting.api.BindingsValuesProvidersByContext;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.osgi.framework.Constants.SERVICE_RANKING;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AdapterImplementations_ImplementationPickerOrderTest {
+
+    @Rule
+    public final OsgiContext context = new OsgiContext();
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private BindingsValuesProvidersByContext bindingsValuesProvidersByContext;
+
+    @Mock
+    private SlingHttpServletRequest request;
+
+    private ModelAdapterFactory factory;
+
+    @Before
+    public void setUp() {
+        context.registerService(BindingsValuesProvidersByContext.class, bindingsValuesProvidersByContext);
+        context.registerService(AdapterManager.class, adapterManager);
+        factory = context.registerInjectActivateService(ModelAdapterFactory.class);
+
+        ModelAdapterFactoryUtil.addModelsForPackage(context.bundleContext(), Model1.class, Model2.class);
+    }
+
+    @Test
+    public void testFirstImplementationPicker() {
+        // LastImplementationPicker has higher priority
+        context.registerInjectActivateService(FirstImplementationPicker.class);
+
+        IntSupplier result = factory.createModel(request, IntSupplier.class);
+        assertEquals(1, result.getAsInt());
+    }
+
+    @Test
+    public void testMultipleImplementationPickers() {
+        // LastImplementationPicker has higher priority
+        context.registerInjectActivateService(FirstImplementationPicker.class);
+        context.registerService(ImplementationPicker.class, new LastImplementationPicker(), SERVICE_RANKING, 100);
+
+        IntSupplier result = factory.createModel(request, IntSupplier.class);
+        assertEquals(2, result.getAsInt());
+    }
+
+    static final class LastImplementationPicker implements ImplementationPicker {
+        @Override
+        public Class<?> pick(
+                @NotNull Class<?> adapterType, Class<?> @NotNull [] implementationsTypes, @NotNull Object adaptable) {
+            return implementationsTypes[implementationsTypes.length - 1];
+        }
+    }
+
+    @Model(adaptables = SlingHttpServletRequest.class, adapters = IntSupplier.class)
+    static final class Model1 implements IntSupplier {
+        @Override
+        public int getAsInt() {
+            return 1;
+        }
+    }
+
+    @Model(adaptables = SlingHttpServletRequest.class, adapters = IntSupplier.class)
+    static final class Model2 implements IntSupplier {
+        @Override
+        public int getAsInt() {
+            return 2;
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/models/impl/ImplementsExtendsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ImplementsExtendsTest.java
@@ -248,7 +248,7 @@ public class ImplementsExtendsTest {
     @Test
     public void testImplementsInterfaceModelWithPickLastImplementationPicker() {
         factory.implementationPickers =
-                Arrays.asList(new AdapterImplementationsTest.LastImplementationPicker(), firstImplementationPicker);
+                Arrays.asList(firstImplementationPicker, new AdapterImplementationsTest.LastImplementationPicker());
 
         Resource res = getMockResourceWithProps();
         SampleServiceInterface model = factory.getAdapter(res, SampleServiceInterface.class);

--- a/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_ImplementationPickerOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_ImplementationPickerOrderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.impl;
+
+import java.util.function.IntSupplier;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.adapter.AdapterManager;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.spi.ImplementationPicker;
+import org.apache.sling.models.testutil.ModelAdapterFactoryUtil;
+import org.apache.sling.scripting.api.BindingsValuesProvidersByContext;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.osgi.framework.Constants.SERVICE_RANKING;
+
+/**
+ * Tests in which order the implementation pickers are handled depending on service ranking.
+ * For historic/backwards compatibility reasons, higher ranking value means lower priority (inverse to DS behavior).
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ModelAdapterFactory_ImplementationPickerOrderTest {
+
+    @Rule
+    public final OsgiContext context = new OsgiContext();
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private BindingsValuesProvidersByContext bindingsValuesProvidersByContext;
+
+    @Mock
+    private SlingHttpServletRequest request;
+
+    private ModelAdapterFactory factory;
+
+    @Before
+    public void setUp() {
+        context.registerService(BindingsValuesProvidersByContext.class, bindingsValuesProvidersByContext);
+        context.registerService(AdapterManager.class, adapterManager);
+        factory = context.registerInjectActivateService(ModelAdapterFactory.class);
+
+        ModelAdapterFactoryUtil.addModelsForPackage(context.bundleContext(), Model1.class, Model2.class);
+    }
+
+    @Test
+    public void testFirstImplementationPicker() {
+        context.registerInjectActivateService(FirstImplementationPicker.class);
+
+        IntSupplier result = factory.createModel(request, IntSupplier.class);
+        assertEquals(1, result.getAsInt());
+    }
+
+    @Test
+    public void testMultipleImplementationPickers() {
+        // LastImplementationPicker has higher priority
+        context.registerInjectActivateService(FirstImplementationPicker.class);
+        context.registerService(ImplementationPicker.class, new LastImplementationPicker(), SERVICE_RANKING, 100);
+
+        IntSupplier result = factory.createModel(request, IntSupplier.class);
+        assertEquals(2, result.getAsInt());
+    }
+
+    static final class LastImplementationPicker implements ImplementationPicker {
+        @Override
+        public Class<?> pick(
+                @NotNull Class<?> adapterType, Class<?>[] implementationsTypes, @NotNull Object adaptable) {
+            return implementationsTypes[implementationsTypes.length - 1];
+        }
+    }
+
+    @Model(adaptables = SlingHttpServletRequest.class, adapters = IntSupplier.class)
+    static final class Model1 implements IntSupplier {
+        @Override
+        public int getAsInt() {
+            return 1;
+        }
+    }
+
+    @Model(adaptables = SlingHttpServletRequest.class, adapters = IntSupplier.class)
+    static final class Model2 implements IntSupplier {
+        @Override
+        public int getAsInt() {
+            return 2;
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_ImplementationPickerOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_ImplementationPickerOrderTest.java
@@ -70,7 +70,8 @@ public class ModelAdapterFactory_ImplementationPickerOrderTest {
 
     @Test
     public void testFirstImplementationPicker() {
-        context.registerInjectActivateService(FirstImplementationPicker.class);
+        context.registerService(
+                ImplementationPicker.class, new FirstImplementationPicker(), SERVICE_RANKING, Integer.MAX_VALUE);
 
         IntSupplier result = factory.createModel(request, IntSupplier.class);
         assertEquals(1, result.getAsInt());
@@ -79,7 +80,8 @@ public class ModelAdapterFactory_ImplementationPickerOrderTest {
     @Test
     public void testMultipleImplementationPickers() {
         // LastImplementationPicker has higher priority
-        context.registerInjectActivateService(FirstImplementationPicker.class); // ranking Integer.MAX_VALUE
+        context.registerService(
+                ImplementationPicker.class, new FirstImplementationPicker(), SERVICE_RANKING, Integer.MAX_VALUE);
         context.registerService(ImplementationPicker.class, new LastImplementationPicker(), SERVICE_RANKING, 100);
 
         IntSupplier result = factory.createModel(request, IntSupplier.class);

--- a/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_ImplementationPickerOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_ImplementationPickerOrderTest.java
@@ -79,7 +79,7 @@ public class ModelAdapterFactory_ImplementationPickerOrderTest {
     @Test
     public void testMultipleImplementationPickers() {
         // LastImplementationPicker has higher priority
-        context.registerInjectActivateService(FirstImplementationPicker.class);
+        context.registerInjectActivateService(FirstImplementationPicker.class); // ranking Integer.MAX_VALUE
         context.registerService(ImplementationPicker.class, new LastImplementationPicker(), SERVICE_RANKING, 100);
 
         IntSupplier result = factory.createModel(request, IntSupplier.class);

--- a/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_InjectorOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_InjectorOrderTest.java
@@ -30,11 +30,9 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.impl.injectors.RequestAttributeInjector;
 import org.apache.sling.models.impl.injectors.ValueMapInjector;
-import org.apache.sling.models.spi.ImplementationPicker;
 import org.apache.sling.models.testutil.ModelAdapterFactoryUtil;
 import org.apache.sling.scripting.api.BindingsValuesProvidersByContext;
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -102,19 +100,11 @@ public class ModelAdapterFactory_InjectorOrderTest {
     @Test
     public void testMultipleInjectors() {
         // ValueMapInjector has higher priority
-        context.registerInjectActivateService(ValueMapInjector.class);
-        context.registerInjectActivateService(RequestAttributeInjector.class);
+        context.registerInjectActivateService(ValueMapInjector.class); // ranking 2000
+        context.registerInjectActivateService(RequestAttributeInjector.class); // ranking 4000
 
         TestModel model = factory.createModel(request, TestModel.class);
         assertEquals((Integer) 1, model.getProp1());
-    }
-
-    static final class LastImplementationPicker implements ImplementationPicker {
-        @Override
-        public Class<?> pick(
-                @NotNull Class<?> adapterType, Class<?>[] implementationsTypes, @NotNull Object adaptable) {
-            return implementationsTypes[implementationsTypes.length - 1];
-        }
     }
 
     @Model(adaptables = SlingHttpServletRequest.class)

--- a/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_InjectorOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_InjectorOrderTest.java
@@ -30,6 +30,7 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.impl.injectors.RequestAttributeInjector;
 import org.apache.sling.models.impl.injectors.ValueMapInjector;
+import org.apache.sling.models.spi.Injector;
 import org.apache.sling.models.testutil.ModelAdapterFactoryUtil;
 import org.apache.sling.scripting.api.BindingsValuesProvidersByContext;
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
@@ -42,6 +43,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
+import static org.osgi.framework.Constants.SERVICE_RANKING;
 
 /**
  * Tests in which order the injectors are handled depending on service ranking.
@@ -83,7 +85,7 @@ public class ModelAdapterFactory_InjectorOrderTest {
 
     @Test
     public void testSingleInjector_ValueMap() {
-        context.registerInjectActivateService(ValueMapInjector.class);
+        context.registerService(Injector.class, new ValueMapInjector(), SERVICE_RANKING, 2000);
 
         TestModel model = factory.createModel(request, TestModel.class);
         assertEquals((Integer) 1, model.getProp1());
@@ -91,7 +93,7 @@ public class ModelAdapterFactory_InjectorOrderTest {
 
     @Test
     public void testSingleInjector_RequestAttribute() {
-        context.registerInjectActivateService(RequestAttributeInjector.class);
+        context.registerService(Injector.class, new RequestAttributeInjector(), SERVICE_RANKING, 4000);
 
         TestModel model = factory.createModel(request, TestModel.class);
         assertEquals((Integer) 2, model.getProp1());
@@ -100,8 +102,8 @@ public class ModelAdapterFactory_InjectorOrderTest {
     @Test
     public void testMultipleInjectors() {
         // ValueMapInjector has higher priority
-        context.registerInjectActivateService(ValueMapInjector.class); // ranking 2000
-        context.registerInjectActivateService(RequestAttributeInjector.class); // ranking 4000
+        context.registerService(Injector.class, new RequestAttributeInjector(), SERVICE_RANKING, 4000);
+        context.registerService(Injector.class, new ValueMapInjector(), SERVICE_RANKING, 2000);
 
         TestModel model = factory.createModel(request, TestModel.class);
         assertEquals((Integer) 1, model.getProp1());

--- a/src/test/java/org/apache/sling/models/impl/MultipleInjectorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/MultipleInjectorTest.java
@@ -64,7 +64,7 @@ public class MultipleInjectorTest {
 
         factory = AdapterFactoryTest.createModelAdapterFactory();
         // binding injector should be asked first as it has a lower service ranking!
-        factory.injectors = Arrays.asList(bindingsInjector, attributesInjector);
+        factory.injectors = Arrays.asList(attributesInjector, bindingsInjector);
         factory.bindStaticInjectAnnotationProcessorFactory(bindingsInjector, new ServicePropertiesMap(1, 1));
 
         when(request.getAttribute(SlingBindings.class.getName())).thenReturn(bindings);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-12472

* adds two new OSGi mock based unit tests which confirms injectors and implementation pickers are handled in REVERSE service ranking order in the implementation
* fix implementation to iterate in reverse order through DS-based reference collections
* adapt other unit tests not actually based on OSGi mock to inject the lists in reverse order to reflect what DS would do