### PR TITLE
SLING-12578 Fix Injector and Implementation Picker service ranking order again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -212,11 +212,8 @@ final class AdapterImplementations {
             implementationsArray[i] = implementationWrappersArray[i].getType();
         }
 
-        // find first-matching implementation (look in service ranking REVERSE order)
-        ImplementationPicker[] localPickers =
-                sortedImplementationPickers.toArray(new ImplementationPicker[sortedImplementationPickers.size()]);
-        for (int pickerIndex = localPickers.length - 1; pickerIndex >= 0; pickerIndex--) {
-            ImplementationPicker picker = localPickers[pickerIndex];
+        // find first-matching implementation (look in service ranking ASCENDING order)
+        for (ImplementationPicker picker : sortedImplementationPickers) {
             Class<?> implementation = picker.pick(adapterType, implementationsArray, adaptable);
             if (implementation != null) {
                 for (int i = 0; i < implementationWrappersArray.length; i++) {

--- a/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelAdapterFactory.java
@@ -572,12 +572,9 @@ public class ModelAdapterFactory implements AdapterFactory, Runnable, ModelFacto
             if (StringUtils.isEmpty(source)) {
                 source = null;
             }
-            // find the right injector (look in service ranking REVERSE order)
-            final Injector[] localInjectors = this.injectors.toArray(new Injector[this.injectors.size()]);
+            // find the right injector (look in service ranking ASCENDING order)
             boolean foundSource = false;
-            for (int injectorIndex = localInjectors.length - 1; injectorIndex >= 0; injectorIndex--) {
-                final Injector injector = localInjectors[injectorIndex];
-
+            for (final Injector injector : this.injectors) {
                 // if a source is given only use injectors with this name.
                 if (source != null && !source.equals(injector.getName())) {
                     continue;

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -136,9 +136,9 @@ public class AdapterImplementationsTest {
                                 SAMPLE_ADAPTER,
                                 SAMPLE_ADAPTABLE,
                                 Arrays.asList(
-                                        new FirstImplementationPicker(),
+                                        new NoneImplementationPicker(),
                                         new LastImplementationPicker(),
-                                        new NoneImplementationPicker()))
+                                        new FirstImplementationPicker()))
                         .getType());
     }
 

--- a/src/test/java/org/apache/sling/models/impl/ImplementsExtendsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ImplementsExtendsTest.java
@@ -248,7 +248,7 @@ public class ImplementsExtendsTest {
     @Test
     public void testImplementsInterfaceModelWithPickLastImplementationPicker() {
         factory.implementationPickers =
-                Arrays.asList(firstImplementationPicker, new AdapterImplementationsTest.LastImplementationPicker());
+                Arrays.asList(new AdapterImplementationsTest.LastImplementationPicker(), firstImplementationPicker);
 
         Resource res = getMockResourceWithProps();
         SampleServiceInterface model = factory.getAdapter(res, SampleServiceInterface.class);

--- a/src/test/java/org/apache/sling/models/impl/MultipleInjectorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/MultipleInjectorTest.java
@@ -64,7 +64,7 @@ public class MultipleInjectorTest {
 
         factory = AdapterFactoryTest.createModelAdapterFactory();
         // binding injector should be asked first as it has a lower service ranking!
-        factory.injectors = Arrays.asList(attributesInjector, bindingsInjector);
+        factory.injectors = Arrays.asList(bindingsInjector, attributesInjector);
         factory.bindStaticInjectAnnotationProcessorFactory(bindingsInjector, new ServicePropertiesMap(1, 1));
 
         when(request.getAttribute(SlingBindings.class.getName())).thenReturn(bindings);


### PR DESCRIPTION
this actually reverts all implementation changes from the wrong bugfix SLING-12472 (#60), but keeps the added more fine-grained unit tests from it which check the correct order handling of Injector and ImplementationPickers in detail. additionally, we update to latest osgi-mock version to test the correct service list order.