### PR TITLE
SLING-12875 - migrate to Sling API 3.x and Jakarta Servlet

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -4,7 +4,7 @@ Import-Package:\
     *
 Provide-Capability:\
     osgi.service;objectClass=java.lang.Runnable,\
-    osgi.service;objectClass=javax.servlet.Servlet,\
+    osgi.service;objectClass=jakarta.servlet.Servlet,\
     osgi.service;objectClass=org.apache.sling.api.adapter.AdapterFactory,\
     osgi.service;objectClass=org.apache.sling.models.factory.ModelFactory
 # Overwrite bundle description due to https://github.com/bndtools/bnd/issues/3282

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <relativePath />
     </parent>
     <artifactId>org.apache.sling.models.impl</artifactId>
-    <version>1.7.9-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Apache Sling Models Implementation</name>
     <description>Apache Sling Models Implementation</description>
 
@@ -38,14 +38,14 @@
     </scm>
     <properties>
         <project.build.outputTimestamp>2024-12-17T10:51:57Z</project.build.outputTimestamp>
-        <sling.java.version>11</sling.java.version>
+        <sling.java.version>17</sling.java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.api</artifactId>
-            <version>1.5.4</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -88,18 +88,31 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.wrappers</artifactId>
+            <version>1.1.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.18.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.25.4</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -127,7 +140,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.core</artifactId>
-            <version>2.4.8</version>
+            <version>3.0.0</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -173,7 +186,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.servlet-helpers</artifactId>
-            <version>1.4.2</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <!-- transitive depedendencies of org.apache.sling.servlet-helpers -->

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.impl.model.ModelClass;
@@ -261,7 +261,8 @@ final class AdapterImplementations {
         if (adaptableType == Resource.class) {
             map = resourceTypeMappingsForResources;
             resourceTypeRemovalLists = resourceTypeRemovalListsForResources;
-        } else if (adaptableType == SlingHttpServletRequest.class) {
+        } else if (adaptableType == SlingJakartaHttpServletRequest.class
+                || adaptableType == org.apache.sling.api.SlingHttpServletRequest.class) {
             map = resourceTypeMappingsForRequests;
             resourceTypeRemovalLists = resourceTypeRemovalListsForRequests;
         } else {
@@ -296,7 +297,15 @@ final class AdapterImplementations {
         }
     }
 
-    public Class<?> getModelClassForRequest(final SlingHttpServletRequest request) {
+    /**
+     * @deprecated use {@link #getModelClassForRequest(SlingJakartaHttpServletRequest) instead
+     */
+    @Deprecated(since = "2.0.0")
+    public Class<?> getModelClassForRequest(final org.apache.sling.api.SlingHttpServletRequest request) {
+        return getModelClassForResource(request.getResource(), resourceTypeMappingsForRequests);
+    }
+
+    public Class<?> getModelClassForRequest(final SlingJakartaHttpServletRequest request) {
         return getModelClassForResource(request.getResource(), resourceTypeMappingsForRequests);
     }
 

--- a/src/main/java/org/apache/sling/models/impl/ExportServlet.java
+++ b/src/main/java/org/apache/sling/models/impl/ExportServlet.java
@@ -19,8 +19,6 @@
 package org.apache.sling.models.impl;
 
 import javax.script.Bindings;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -28,12 +26,14 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.scripting.LazyBindings;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
-import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.api.servlets.SlingJakartaSafeMethodsServlet;
 import org.apache.sling.models.factory.ExportException;
 import org.apache.sling.models.factory.MissingExporterException;
 import org.apache.sling.models.factory.ModelFactory;
@@ -43,16 +43,16 @@ import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.sling.api.scripting.SlingBindings.JAKARTA_REQUEST;
+import static org.apache.sling.api.scripting.SlingBindings.JAKARTA_RESPONSE;
 import static org.apache.sling.api.scripting.SlingBindings.LOG;
 import static org.apache.sling.api.scripting.SlingBindings.OUT;
 import static org.apache.sling.api.scripting.SlingBindings.READER;
-import static org.apache.sling.api.scripting.SlingBindings.REQUEST;
 import static org.apache.sling.api.scripting.SlingBindings.RESOURCE;
-import static org.apache.sling.api.scripting.SlingBindings.RESPONSE;
 import static org.apache.sling.api.scripting.SlingBindings.SLING;
 
 @SuppressWarnings("serial")
-class ExportServlet extends SlingSafeMethodsServlet {
+class ExportServlet extends SlingJakartaSafeMethodsServlet {
 
     private static final String APPLICATION_JSON = "application/json";
     private static final String UTF_8 = "UTF-8";
@@ -92,7 +92,7 @@ class ExportServlet extends SlingSafeMethodsServlet {
     }
 
     @Override
-    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+    protected void doGet(SlingJakartaHttpServletRequest request, SlingJakartaHttpServletResponse response)
             throws ServletException, IOException {
         String contentType = request.getResponseContentType();
         response.setContentType(contentType);
@@ -131,15 +131,17 @@ class ExportServlet extends SlingSafeMethodsServlet {
     }
 
     private void addScriptBindings(
-            SlingScriptHelper scriptHelper, SlingHttpServletRequest request, SlingHttpServletResponse response)
+            SlingScriptHelper scriptHelper,
+            SlingJakartaHttpServletRequest request,
+            SlingJakartaHttpServletResponse response)
             throws IOException {
         Bindings bindings = new LazyBindings();
         bindings.put(SLING, scriptHelper);
         bindings.put(RESOURCE, request.getResource());
         bindings.put(
                 SlingModelsScriptEngineFactory.RESOLVER, request.getResource().getResourceResolver());
-        bindings.put(REQUEST, request);
-        bindings.put(RESPONSE, response);
+        bindings.put(JAKARTA_REQUEST, request);
+        bindings.put(JAKARTA_RESPONSE, response);
         try {
             bindings.put(READER, request.getReader());
         } catch (Exception e) {
@@ -156,7 +158,7 @@ class ExportServlet extends SlingSafeMethodsServlet {
         request.setAttribute(SlingBindings.class.getName(), slingBindings);
     }
 
-    private Map<String, String> createOptionMap(SlingHttpServletRequest request) {
+    private Map<String, String> createOptionMap(SlingJakartaHttpServletRequest request) {
         Map<String, String[]> parameterMap = request.getParameterMap();
         String[] selectors = request.getRequestPathInfo().getSelectors();
         Map<String, String> result =
@@ -180,7 +182,7 @@ class ExportServlet extends SlingSafeMethodsServlet {
 
     public interface ExportedObjectAccessor {
         String getExportedString(
-                SlingHttpServletRequest request,
+                SlingJakartaHttpServletRequest request,
                 Map<String, String> options,
                 ModelFactory modelFactory,
                 String exporterName)
@@ -197,7 +199,7 @@ class ExportServlet extends SlingSafeMethodsServlet {
 
         @Override
         public String getExportedString(
-                SlingHttpServletRequest request,
+                SlingJakartaHttpServletRequest request,
                 Map<String, String> options,
                 ModelFactory modelFactory,
                 String exporterName)
@@ -217,7 +219,7 @@ class ExportServlet extends SlingSafeMethodsServlet {
 
         @Override
         public String getExportedString(
-                SlingHttpServletRequest request,
+                SlingJakartaHttpServletRequest request,
                 Map<String, String> options,
                 ModelFactory modelFactory,
                 String exporterName)

--- a/src/main/java/org/apache/sling/models/impl/ModelConfigurationPrinter.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelConfigurationPrinter.java
@@ -18,13 +18,12 @@
  */
 package org.apache.sling.models.impl;
 
-import javax.servlet.Servlet;
-
 import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.servlet.Servlet;
 import org.apache.sling.models.annotations.ViaProviderType;
 import org.apache.sling.models.spi.ImplementationPicker;
 import org.apache.sling.models.spi.Injector;

--- a/src/main/java/org/apache/sling/models/impl/ModelPackageBundleListener.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelPackageBundleListener.java
@@ -18,8 +18,6 @@
  */
 package org.apache.sling.models.impl;
 
-import javax.servlet.Servlet;
-
 import java.lang.annotation.AnnotationFormatError;
 import java.net.URL;
 import java.util.ArrayList;
@@ -31,9 +29,10 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.servlet.Servlet;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
@@ -169,7 +168,8 @@ public class ModelPackageBundleListener implements BundleTrackerCustomizer<Servi
                                     ExportServlet.ExportedObjectAccessor accessor = null;
                                     if (adaptable == Resource.class) {
                                         accessor = new ExportServlet.ResourceAccessor(implType);
-                                    } else if (adaptable == SlingHttpServletRequest.class) {
+                                    } else if (adaptable == SlingJakartaHttpServletRequest.class
+                                            || adaptable == org.apache.sling.api.SlingHttpServletRequest.class) {
                                         accessor = new ExportServlet.RequestAccessor(implType);
                                     }
                                     Exporter exporterAnnotation = implType.getAnnotation(Exporter.class);

--- a/src/main/java/org/apache/sling/models/impl/ResourceOverridingJakartaRequestWrapper.java
+++ b/src/main/java/org/apache/sling/models/impl/ResourceOverridingJakartaRequestWrapper.java
@@ -20,34 +20,32 @@ package org.apache.sling.models.impl;
 
 import javax.script.Bindings;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingBindings;
-import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.api.wrappers.SlingJakartaHttpServletRequestWrapper;
 import org.apache.sling.scripting.api.BindingsValuesProvidersByContext;
 
+import static org.apache.sling.api.scripting.SlingBindings.JAKARTA_REQUEST;
+import static org.apache.sling.api.scripting.SlingBindings.JAKARTA_RESPONSE;
 import static org.apache.sling.api.scripting.SlingBindings.LOG;
 import static org.apache.sling.api.scripting.SlingBindings.OUT;
 import static org.apache.sling.api.scripting.SlingBindings.READER;
-import static org.apache.sling.api.scripting.SlingBindings.REQUEST;
 import static org.apache.sling.api.scripting.SlingBindings.RESOURCE;
-import static org.apache.sling.api.scripting.SlingBindings.RESPONSE;
 import static org.apache.sling.api.scripting.SlingBindings.SLING;
 
 /**
  * This request wrapper allows to adapt the given resource and request to a Sling Model
- * @deprecated use {@link ResourceOverridingJakartaRequestWrapper} instead
  */
-@Deprecated(since = "2.0.0")
-class ResourceOverridingRequestWrapper extends SlingHttpServletRequestWrapper {
+class ResourceOverridingJakartaRequestWrapper extends SlingJakartaHttpServletRequestWrapper {
 
     private final Resource resource;
     private final AdapterManager adapterManager;
     private final Bindings bindings;
 
-    ResourceOverridingRequestWrapper(
-            SlingHttpServletRequest wrappedRequest,
+    ResourceOverridingJakartaRequestWrapper(
+            SlingJakartaHttpServletRequest wrappedRequest,
             Resource resource,
             AdapterManager adapterManager,
             SlingModelsScriptEngineFactory scriptEngineFactory,
@@ -61,12 +59,12 @@ class ResourceOverridingRequestWrapper extends SlingHttpServletRequestWrapper {
         bindings = new SlingBindings();
         if (existingBindings != null) {
             bindings.put(SLING, existingBindings.getSling());
-            bindings.put(RESPONSE, existingBindings.getResponse());
+            bindings.put(JAKARTA_RESPONSE, existingBindings.getJakartaResponse());
             bindings.put(READER, existingBindings.getReader());
             bindings.put(OUT, existingBindings.getOut());
             bindings.put(LOG, existingBindings.getLog());
         }
-        bindings.put(REQUEST, this);
+        bindings.put(JAKARTA_REQUEST, this);
         bindings.put(RESOURCE, resource);
         bindings.put(SlingModelsScriptEngineFactory.RESOLVER, resource.getResourceResolver());
 

--- a/src/main/java/org/apache/sling/models/impl/ResourceTypeBasedResourcePicker.java
+++ b/src/main/java/org/apache/sling/models/impl/ResourceTypeBasedResourcePicker.java
@@ -21,7 +21,7 @@ package org.apache.sling.models.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.spi.ImplementationPicker;
@@ -45,10 +45,12 @@ public class ResourceTypeBasedResourcePicker implements ImplementationPicker {
     }
 
     private Resource findResource(Object adaptable) {
-        if (adaptable instanceof Resource) {
-            return (Resource) adaptable;
-        } else if (adaptable instanceof SlingHttpServletRequest) {
-            return ((SlingHttpServletRequest) adaptable).getResource();
+        if (adaptable instanceof Resource resource) {
+            return resource;
+        } else if (adaptable instanceof SlingJakartaHttpServletRequest jakartaRequest) {
+            return jakartaRequest.getResource();
+        } else if (adaptable instanceof org.apache.sling.api.SlingHttpServletRequest javaxRequest) {
+            return javaxRequest.getResource();
         } else {
             return null;
         }

--- a/src/main/java/org/apache/sling/models/impl/SlingModelsScriptEngineFactory.java
+++ b/src/main/java/org/apache/sling/models/impl/SlingModelsScriptEngineFactory.java
@@ -48,8 +48,8 @@ class SlingModelsScriptEngineFactory extends AbstractScriptEngineFactory impleme
     static final String RESOLVER = "resolver";
 
     /** The set of protected keys. */
-    private static final Set<String> PROTECTED_KEYS =
-            new HashSet<String>(Arrays.asList(REQUEST, RESPONSE, READER, SLING, RESOURCE, RESOLVER, OUT, LOG));
+    private static final Set<String> PROTECTED_KEYS = new HashSet<String>(Arrays.asList(
+            REQUEST, RESPONSE, JAKARTA_REQUEST, JAKARTA_RESPONSE, READER, SLING, RESOURCE, RESOLVER, OUT, LOG));
 
     SlingModelsScriptEngineFactory(Bundle bundle) {
         super();

--- a/src/main/java/org/apache/sling/models/impl/injectors/AbstractInjector.java
+++ b/src/main/java/org/apache/sling/models/impl/injectors/AbstractInjector.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.adapter.Adaptable;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -37,10 +37,12 @@ abstract class AbstractInjector {
 
     protected ResourceResolver getResourceResolver(Object adaptable) {
         ResourceResolver resolver = null;
-        if (adaptable instanceof Resource) {
-            resolver = ((Resource) adaptable).getResourceResolver();
-        } else if (adaptable instanceof SlingHttpServletRequest) {
-            resolver = ((SlingHttpServletRequest) adaptable).getResourceResolver();
+        if (adaptable instanceof Resource r) {
+            resolver = r.getResourceResolver();
+        } else if (adaptable instanceof SlingJakartaHttpServletRequest jakartaRequest) {
+            resolver = jakartaRequest.getResourceResolver();
+        } else if (adaptable instanceof org.apache.sling.api.SlingHttpServletRequest javaxRequest) {
+            resolver = javaxRequest.getResourceResolver();
         }
         return resolver;
     }
@@ -49,7 +51,7 @@ abstract class AbstractInjector {
      * Retrieve the ValueMap from the given adaptable. This succeeds, if the adaptable is either
      * <ul>
      * <li>a {@link ValueMap},</li>
-     * <li>a {@link SlingHttpServletRequest}, in which case the returned {@link ValueMap} is the one derived from the request's resource or</li>
+     * <li>a {@link SlingJakartaHttpServletRequest} or {@link SlingHttpServletRequest}, in which case the returned {@link ValueMap} is the one derived from the request's resource or</li>
      * <li>adaptable to a {@link ValueMap}.</li>
      * </ul>
      * Otherwise {@code null} is returned.
@@ -57,27 +59,31 @@ abstract class AbstractInjector {
      * @return a ValueMap or {@code null}.
      */
     protected @Nullable ValueMap getValueMap(Object adaptable) {
-        if (adaptable instanceof ValueMap) {
-            return (ValueMap) adaptable;
-        } else if (adaptable instanceof SlingHttpServletRequest) {
-            final Resource resource = ((SlingHttpServletRequest) adaptable).getResource();
-            // resource may be null for mocked adaptables, therefore do a check here
-            if (resource != null) {
-                return resource.adaptTo(ValueMap.class);
-            } else {
-                return null;
-            }
-        } else if (adaptable instanceof Adaptable) {
-            return ((Adaptable) adaptable).adaptTo(ValueMap.class);
-        } else {
-            return null;
+        ValueMap valueMap = null;
+        if (adaptable instanceof ValueMap vm) {
+            valueMap = vm;
+        } else if (adaptable instanceof SlingJakartaHttpServletRequest jakartaRequest) {
+            valueMap = toValueMap(jakartaRequest.getResource());
+        } else if (adaptable instanceof org.apache.sling.api.SlingHttpServletRequest javaxRequest) {
+            valueMap = toValueMap(javaxRequest.getResource());
+        } else if (adaptable instanceof Adaptable a) {
+            valueMap = a.adaptTo(ValueMap.class);
         }
+        return valueMap;
+    }
+
+    protected @Nullable ValueMap toValueMap(final Resource resource) {
+        ValueMap valueMap = null;
+        // resource may be null for mocked adaptables, therefore do a check here
+        if (resource != null) {
+            valueMap = resource.adaptTo(ValueMap.class);
+        }
+        return valueMap;
     }
 
     protected boolean isDeclaredTypeCollection(Type declaredType) {
         boolean isCollection = false;
-        if (declaredType instanceof ParameterizedType) {
-            ParameterizedType type = (ParameterizedType) declaredType;
+        if (declaredType instanceof ParameterizedType type) {
             Class<?> collectionType = (Class<?>) type.getRawType();
             isCollection = collectionType.equals(Collection.class) || collectionType.equals(List.class);
         }

--- a/src/main/java/org/apache/sling/models/impl/injectors/BindingsInjector.java
+++ b/src/main/java/org/apache/sling/models/impl/injectors/BindingsInjector.java
@@ -18,11 +18,10 @@
  */
 package org.apache.sling.models.impl.injectors;
 
-import javax.servlet.ServletRequest;
-
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
 
+import jakarta.servlet.ServletRequest;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
@@ -65,11 +64,12 @@ public class BindingsInjector implements Injector, StaticInjectAnnotationProcess
     }
 
     private SlingBindings getBindings(Object adaptable) {
-        if (adaptable instanceof SlingBindings) {
-            return (SlingBindings) adaptable;
-        } else if (adaptable instanceof ServletRequest) {
-            ServletRequest request = (ServletRequest) adaptable;
-            return (SlingBindings) request.getAttribute(SlingBindings.class.getName());
+        if (adaptable instanceof SlingBindings bindings) {
+            return bindings;
+        } else if (adaptable instanceof ServletRequest jakartaRequest) {
+            return (SlingBindings) jakartaRequest.getAttribute(SlingBindings.class.getName());
+        } else if (adaptable instanceof javax.servlet.ServletRequest javaxRequest) {
+            return (SlingBindings) javaxRequest.getAttribute(SlingBindings.class.getName());
         } else {
             return null;
         }

--- a/src/main/java/org/apache/sling/models/impl/injectors/ChildResourceInjector.java
+++ b/src/main/java/org/apache/sling/models/impl/injectors/ChildResourceInjector.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.injectorspecific.ChildResource;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
@@ -56,8 +56,8 @@ public class ChildResourceInjector extends AbstractInjector implements Injector,
             @NotNull Type declaredType,
             @NotNull AnnotatedElement element,
             @NotNull DisposalCallbackRegistry callbackRegistry) {
-        if (adaptable instanceof Resource) {
-            Resource child = ((Resource) adaptable).getChild(name);
+        if (adaptable instanceof Resource resource) {
+            Resource child = resource.getChild(name);
             if (child != null) {
                 return getValue(child, declaredType);
             }
@@ -143,7 +143,8 @@ public class ChildResourceInjector extends AbstractInjector implements Injector,
                 return annotation.via();
             }
             // automatically go via resource, if this is the httprequest
-            if (adaptable instanceof SlingHttpServletRequest) {
+            if (adaptable instanceof SlingJakartaHttpServletRequest
+                    || adaptable instanceof org.apache.sling.api.SlingHttpServletRequest) {
                 return "resource";
             } else {
                 return null;

--- a/src/main/java/org/apache/sling/models/impl/injectors/RequestAttributeInjector.java
+++ b/src/main/java/org/apache/sling/models/impl/injectors/RequestAttributeInjector.java
@@ -18,11 +18,10 @@
  */
 package org.apache.sling.models.impl.injectors;
 
-import javax.servlet.ServletRequest;
-
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
 
+import jakarta.servlet.ServletRequest;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.RequestAttribute;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
@@ -51,10 +50,12 @@ public class RequestAttributeInjector implements Injector, StaticInjectAnnotatio
             @NotNull Type declaredType,
             @NotNull AnnotatedElement element,
             @NotNull DisposalCallbackRegistry callbackRegistry) {
-        if (!(adaptable instanceof ServletRequest)) {
-            return null;
+        if (adaptable instanceof ServletRequest jakartaRequest) {
+            return jakartaRequest.getAttribute(name);
+        } else if (adaptable instanceof javax.servlet.ServletRequest javaxRequest) {
+            return javaxRequest.getAttribute(name);
         } else {
-            return ((ServletRequest) adaptable).getAttribute(name);
+            return null;
         }
     }
 

--- a/src/main/java/org/apache/sling/models/impl/injectors/SlingObjectInjector.java
+++ b/src/main/java/org/apache/sling/models/impl/injectors/SlingObjectInjector.java
@@ -18,18 +18,19 @@
  */
 package org.apache.sling.models.impl.injectors;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.api.wrappers.JakartaToJavaxRequestWrapper;
+import org.apache.sling.api.wrappers.JavaxToJakartaRequestWrapper;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.spi.AcceptsNullName;
@@ -76,33 +77,47 @@ public final class SlingObjectInjector implements Injector, StaticInjectAnnotati
         }
         Class<?> requestedClass = (Class<?>) type;
 
+        SlingJakartaHttpServletRequest jakartaRequest = null;
+        Supplier<org.apache.sling.api.SlingHttpServletRequest> javaxRequestSupplier = null;
+        if (adaptable instanceof SlingJakartaHttpServletRequest jr) {
+            jakartaRequest = jr;
+            javaxRequestSupplier = () -> JakartaToJavaxRequestWrapper.toJavaxRequest(jr);
+        } else if (adaptable instanceof org.apache.sling.api.SlingHttpServletRequest r) {
+            jakartaRequest = JavaxToJakartaRequestWrapper.toJakartaRequest(r);
+            javaxRequestSupplier = () -> r;
+        }
         // validate input
-        if (adaptable instanceof SlingHttpServletRequest) {
-            SlingHttpServletRequest request = (SlingHttpServletRequest) adaptable;
+        if (jakartaRequest != null) {
             if (requestedClass.equals(ResourceResolver.class)) {
-                return request.getResourceResolver();
+                return jakartaRequest.getResourceResolver();
             }
             if (requestedClass.equals(Resource.class) && element.isAnnotationPresent(SlingObject.class)) {
-                return request.getResource();
+                return jakartaRequest.getResource();
             }
-            if (requestedClass.equals(SlingHttpServletRequest.class)
-                    || requestedClass.equals(HttpServletRequest.class)) {
-                return request;
+            if (requestedClass.equals(SlingJakartaHttpServletRequest.class)
+                    || requestedClass.equals(jakarta.servlet.http.HttpServletRequest.class)) {
+                return jakartaRequest;
             }
-            if (requestedClass.equals(SlingHttpServletResponse.class)
-                    || requestedClass.equals(HttpServletResponse.class)) {
-                return getSlingHttpServletResponse(request);
+            if (requestedClass.equals(SlingJakartaHttpServletResponse.class)
+                    || requestedClass.equals(jakarta.servlet.http.HttpServletResponse.class)) {
+                return getScriptHelperItem(jakartaRequest, SlingScriptHelper::getJakartaResponse);
+            }
+            if (requestedClass.equals(org.apache.sling.api.SlingHttpServletRequest.class)
+                    || requestedClass.equals(javax.servlet.http.HttpServletRequest.class)) {
+                return javaxRequestSupplier.get();
+            }
+            if (requestedClass.equals(org.apache.sling.api.SlingHttpServletResponse.class)
+                    || requestedClass.equals(javax.servlet.http.HttpServletResponse.class)) {
+                return getScriptHelperItem(jakartaRequest, SlingScriptHelper::getResponse);
             }
             if (requestedClass.equals(SlingScriptHelper.class)) {
-                return getSlingScriptHelper(request);
+                return getSlingJakartaScriptHelper(jakartaRequest);
             }
-        } else if (adaptable instanceof ResourceResolver) {
-            ResourceResolver resourceResolver = (ResourceResolver) adaptable;
+        } else if (adaptable instanceof ResourceResolver resourceResolver) {
             if (requestedClass.equals(ResourceResolver.class)) {
                 return resourceResolver;
             }
-        } else if (adaptable instanceof Resource) {
-            Resource resource = (Resource) adaptable;
+        } else if (adaptable instanceof Resource resource) {
             if (requestedClass.equals(ResourceResolver.class)) {
                 return resource.getResourceResolver();
             }
@@ -114,20 +129,22 @@ public final class SlingObjectInjector implements Injector, StaticInjectAnnotati
         return null;
     }
 
-    private SlingScriptHelper getSlingScriptHelper(final SlingHttpServletRequest request) {
+    private SlingScriptHelper getSlingJakartaScriptHelper(final SlingJakartaHttpServletRequest request) {
+        SlingScriptHelper value = null;
         SlingBindings bindings = (SlingBindings) request.getAttribute(SlingBindings.class.getName());
         if (bindings != null) {
-            return bindings.getSling();
+            value = bindings.getSling();
         }
-        return null;
+        return value;
     }
 
-    private SlingHttpServletResponse getSlingHttpServletResponse(final SlingHttpServletRequest request) {
-        SlingScriptHelper scriptHelper = getSlingScriptHelper(request);
+    private <T> T getScriptHelperItem(final SlingJakartaHttpServletRequest request, Function<SlingScriptHelper, T> fn) {
+        T value = null;
+        SlingScriptHelper scriptHelper = getSlingJakartaScriptHelper(request);
         if (scriptHelper != null) {
-            return scriptHelper.getResponse();
+            value = fn.apply(scriptHelper);
         }
-        return null;
+        return value;
     }
 
     @Override

--- a/src/main/java/org/apache/sling/models/impl/via/AbstractResourceTypeViaProvider.java
+++ b/src/main/java/org/apache/sling/models/impl/via/AbstractResourceTypeViaProvider.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sling.models.impl.via;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.spi.ViaProvider;
 import org.jetbrains.annotations.NotNull;
@@ -35,17 +35,15 @@ public abstract class AbstractResourceTypeViaProvider implements ViaProvider {
         if (!handle(value)) {
             return ORIGINAL;
         }
-        if (original instanceof Resource) {
-            final Resource resource = (Resource) original;
+        if (original instanceof Resource resource) {
             final String resourceType = getResourceType(resource, value);
             if (resourceType == null) {
                 log.warn("Could not determine forced resource type for {} using via value {}.", resource, value);
                 return null;
             }
             return new ResourceTypeForcingResourceWrapper(resource, resourceType);
-        } else if (original instanceof SlingHttpServletRequest) {
-            final SlingHttpServletRequest request = (SlingHttpServletRequest) original;
-            final Resource resource = request.getResource();
+        } else if (original instanceof SlingJakartaHttpServletRequest jakartaRequest) {
+            final Resource resource = jakartaRequest.getResource();
             if (resource == null) {
                 return null;
             }
@@ -54,7 +52,18 @@ public abstract class AbstractResourceTypeViaProvider implements ViaProvider {
                 log.warn("Could not determine forced resource type for {} using via value {}.", resource, value);
                 return null;
             }
-            return new ResourceTypeForcingRequestWrapper(request, resource, resourceType);
+            return new ResourceTypeForcingJakartaRequestWrapper(jakartaRequest, resource, resourceType);
+        } else if (original instanceof org.apache.sling.api.SlingHttpServletRequest javaxRequest) {
+            final Resource resource = javaxRequest.getResource();
+            if (resource == null) {
+                return null;
+            }
+            final String resourceType = getResourceType(resource, value);
+            if (resourceType == null) {
+                log.warn("Could not determine forced resource type for {} using via value {}.", resource, value);
+                return null;
+            }
+            return new ResourceTypeForcingRequestWrapper(javaxRequest, resource, resourceType);
         } else {
             log.warn(
                     "Received unexpected adaptable of type {}.",

--- a/src/main/java/org/apache/sling/models/impl/via/OriginalResourceTypeViaProvider.java
+++ b/src/main/java/org/apache/sling/models/impl/via/OriginalResourceTypeViaProvider.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sling.models.impl.via;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.ViaProviderType;
 import org.apache.sling.models.annotations.via.OriginalResourceType;
@@ -28,10 +28,11 @@ import org.osgi.service.component.annotations.Component;
 /**
  * This {@link ViaProvider} implements the counterpart of the {@link ForcedResourceTypeViaProvider} and the
  * {@link ResourceSuperTypeViaProvider}. It is in particular helpful in models that want to inject another model using the original
- * {@link Resource}'s or {@link SlingHttpServletRequest}'s resource type instead of the one forced by either of the above-mentioned
+ * {@link Resource}'s, {@link SlingJakartaHttpServletRequest}'s or {@link SlingHttpServletRequest}'s resource type instead of the one forced by either of the above-mentioned
  * {@link ViaProvider}s
  * <p>
- * The implementation simply unwraps the {@link org.apache.sling.api.resource.ResourceWrapper} or
+ * The implementation simply unwraps the {@link org.apache.sling.api.resource.ResourceWrapper},
+ * {@link org.apache.sling.api.wrappers.SlingJakartaHttpServletRequestWrapper} or
  * {@link org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper} used by the {@link ForcedResourceTypeViaProvider} and
  * {@link ResourceSuperTypeViaProvider}.
  */
@@ -45,16 +46,19 @@ public class OriginalResourceTypeViaProvider implements ViaProvider {
 
     @Override
     public Object getAdaptable(Object original, String value) {
-        if (original instanceof SlingHttpServletRequest) {
-            SlingHttpServletRequest originalRequest = (SlingHttpServletRequest) original;
-            while (originalRequest instanceof ResourceTypeForcingRequestWrapper) {
-                originalRequest = ((ResourceTypeForcingRequestWrapper) originalRequest).getSlingRequest();
+        if (original instanceof SlingJakartaHttpServletRequest originalRequest) {
+            while (originalRequest instanceof ResourceTypeForcingJakartaRequestWrapper jakartaRequest) {
+                originalRequest = jakartaRequest.getSlingRequest();
             }
             return originalRequest;
-        } else if (original instanceof Resource) {
-            Resource originalResource = (Resource) original;
-            while (originalResource instanceof ResourceTypeForcingResourceWrapper) {
-                originalResource = ((ResourceTypeForcingResourceWrapper) originalResource).getResource();
+        } else if (original instanceof org.apache.sling.api.SlingHttpServletRequest originalRequest) {
+            while (originalRequest instanceof ResourceTypeForcingRequestWrapper javaxRequest) {
+                originalRequest = javaxRequest.getSlingRequest();
+            }
+            return originalRequest;
+        } else if (original instanceof Resource originalResource) {
+            while (originalResource instanceof ResourceTypeForcingResourceWrapper wrapper) {
+                originalResource = wrapper.getResource();
             }
             return originalResource;
         } else {

--- a/src/main/java/org/apache/sling/models/impl/via/ResourceTypeForcingJakartaRequestWrapper.java
+++ b/src/main/java/org/apache/sling/models/impl/via/ResourceTypeForcingJakartaRequestWrapper.java
@@ -16,16 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.sling.models.testmodels.classes.constructorvisibility;
-
-import javax.inject.Inject;
+package org.apache.sling.models.impl.via;
 
 import org.apache.sling.api.SlingJakartaHttpServletRequest;
-import org.apache.sling.models.annotations.Model;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.wrappers.SlingJakartaHttpServletRequestWrapper;
 
-@Model(adaptables = SlingJakartaHttpServletRequest.class)
-public class PackagePrivateConstructorModel {
+class ResourceTypeForcingJakartaRequestWrapper extends SlingJakartaHttpServletRequestWrapper {
 
-    @Inject
-    PackagePrivateConstructorModel() {}
+    private final Resource resource;
+
+    ResourceTypeForcingJakartaRequestWrapper(
+            SlingJakartaHttpServletRequest request, Resource resource, String resourceType) {
+        super(request);
+        this.resource = new ResourceTypeForcingResourceWrapper(resource, resourceType);
+    }
+
+    @Override
+    public Resource getResource() {
+        return resource;
+    }
 }

--- a/src/main/java/org/apache/sling/models/impl/via/ResourceTypeForcingRequestWrapper.java
+++ b/src/main/java/org/apache/sling/models/impl/via/ResourceTypeForcingRequestWrapper.java
@@ -22,6 +22,10 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
 
+/**
+ * @deprecated use {@link ResourceTypeForcingJakartaRequestWrapper} instead
+ */
+@Deprecated(since = "2.0.0")
 class ResourceTypeForcingRequestWrapper extends SlingHttpServletRequestWrapper {
 
     private final Resource resource;

--- a/src/test/java/org/apache/sling/models/impl/AdapterFactoryTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterFactoryTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -66,7 +66,7 @@ public class AdapterFactoryTest {
     private Resource resource;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     private ModelAdapterFactory factory;
 
@@ -141,7 +141,7 @@ public class AdapterFactoryTest {
         factory.createModel(resource, ConstructorWithExceptionModel.class);
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     public static class NestedModelWithInvalidAdaptable {
         @Self
         DefaultStringModel nestedModel;
@@ -153,7 +153,7 @@ public class AdapterFactoryTest {
         factory.createModel(request, NestedModelWithInvalidAdaptable.class);
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     public static class NestedModelWithInvalidAdaptable2 {
         @Self
         InvalidModelWithMissingAnnotation nestedModel;
@@ -331,7 +331,7 @@ public class AdapterFactoryTest {
 
         for (long i = 0; i < maxInstances; i++) {
             CachedModelWithSelfReference model =
-                    factory.createModel(mock(SlingHttpServletRequest.class), CachedModelWithSelfReference.class);
+                    factory.createModel(mock(SlingJakartaHttpServletRequest.class), CachedModelWithSelfReference.class);
             for (int j = 0; j < model.longs.length; j++) {
                 model.longs[j] = j;
             }

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -20,7 +20,7 @@ package org.apache.sling.models.impl;
 
 import java.util.Arrays;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.spi.ImplementationPicker;
@@ -53,7 +53,7 @@ public class AdapterImplementationsTest {
     private Resource childResource;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
     private ResourceResolver resourceResolver;
@@ -251,7 +251,7 @@ public class AdapterImplementationsTest {
         // now add a mapping for SlingHttpServletRequest -> String
         BundleContext bundleContext = MockOsgi.newBundleContext();
         underTest.registerModelToResourceType(
-                bundleContext.getBundle(), "sling/rt/one", SlingHttpServletRequest.class, String.class);
+                bundleContext.getBundle(), "sling/rt/one", SlingJakartaHttpServletRequest.class, String.class);
         underTest.registerModelToResourceType(bundleContext.getBundle(), "sling/rt/one", Resource.class, Integer.class);
         assertEquals(String.class, underTest.getModelClassForRequest(request));
         assertEquals(Integer.class, underTest.getModelClassForResource(resource));
@@ -259,7 +259,7 @@ public class AdapterImplementationsTest {
         // ensure that trying to reregister the resource type is a no-op
         BundleContext secondBundleContext = MockOsgi.newBundleContext();
         underTest.registerModelToResourceType(
-                secondBundleContext.getBundle(), "sling/rt/one", SlingHttpServletRequest.class, Integer.class);
+                secondBundleContext.getBundle(), "sling/rt/one", SlingJakartaHttpServletRequest.class, Integer.class);
         assertEquals(String.class, underTest.getModelClassForRequest(request));
 
         underTest.removeResourceTypeBindings(bundleContext.getBundle());

--- a/src/test/java/org/apache/sling/models/impl/CachingTest.java
+++ b/src/test/java/org/apache/sling/models/impl/CachingTest.java
@@ -24,7 +24,7 @@ import java.util.Enumeration;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.api.wrappers.SlingJakartaHttpServletRequestWrapper;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.models.impl.injectors.RequestAttributeInjector;
 import org.apache.sling.models.impl.injectors.ValueMapInjector;
@@ -35,7 +35,7 @@ import org.apache.sling.models.testmodels.classes.UncachedModel;
 import org.apache.sling.models.testmodels.interfaces.AdapterType1;
 import org.apache.sling.models.testmodels.interfaces.AdapterType2;
 import org.apache.sling.models.testmodels.interfaces.AdapterType3;
-import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
+import org.apache.sling.servlethelpers.MockSlingJakartaHttpServletRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,9 +54,9 @@ import static org.mockito.Mockito.when;
 public class CachingTest {
 
     @Spy
-    private MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(null);
+    private MockSlingJakartaHttpServletRequest request = new MockSlingJakartaHttpServletRequest(null);
 
-    private SlingHttpServletRequestWrapper requestWrapper;
+    private SlingJakartaHttpServletRequestWrapper requestWrapper;
 
     @Mock
     private Resource resource;
@@ -84,7 +84,7 @@ public class CachingTest {
                 AdapterType3.class);
 
         when(request.getAttribute("testValue")).thenReturn("test");
-        requestWrapper = new SlingHttpServletRequestWrapper(request);
+        requestWrapper = new SlingJakartaHttpServletRequestWrapper(request);
 
         ValueMap vm = new ValueMapDecorator(Collections.singletonMap("testValue", "test"));
         when(resource.adaptTo(ValueMap.class)).thenReturn(vm);

--- a/src/test/java/org/apache/sling/models/impl/ConstructorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ConstructorTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.request.RequestPathInfo;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.factory.ModelClassException;
@@ -63,7 +63,7 @@ public class ConstructorTest {
     private ModelAdapterFactory factory;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     private static final int INT_VALUE = 42;
 

--- a/src/test/java/org/apache/sling/models/impl/ConstructorVisibilityTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ConstructorVisibilityTest.java
@@ -20,7 +20,7 @@ package org.apache.sling.models.impl;
 
 import java.util.Arrays;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.impl.injectors.RequestAttributeInjector;
 import org.apache.sling.models.impl.injectors.SelfInjector;
 import org.apache.sling.models.testmodels.classes.constructorvisibility.PackagePrivateConstructorModel;
@@ -39,7 +39,7 @@ public class ConstructorVisibilityTest {
     private ModelAdapterFactory factory;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Before
     public void setup() {

--- a/src/test/java/org/apache/sling/models/impl/InjectorSpecificAnnotationTest.java
+++ b/src/test/java/org/apache/sling/models/impl/InjectorSpecificAnnotationTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.scripting.SlingBindings;
@@ -63,7 +63,7 @@ public class InjectorSpecificAnnotationTest {
     private BundleContext bundleContext;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
     private Logger log;

--- a/src/test/java/org/apache/sling/models/impl/InvalidAdaptationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/InvalidAdaptationsTest.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -93,6 +93,6 @@ public class InvalidAdaptationsTest {
 
     private class NonModel {}
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     private class RequestModel {}
 }

--- a/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_ImplementationPickerOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_ImplementationPickerOrderTest.java
@@ -20,7 +20,7 @@ package org.apache.sling.models.impl;
 
 import java.util.function.IntSupplier;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.spi.ImplementationPicker;
@@ -55,7 +55,7 @@ public class ModelAdapterFactory_ImplementationPickerOrderTest {
     private BindingsValuesProvidersByContext bindingsValuesProvidersByContext;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     private ModelAdapterFactory factory;
 
@@ -96,7 +96,7 @@ public class ModelAdapterFactory_ImplementationPickerOrderTest {
         }
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class, adapters = IntSupplier.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class, adapters = IntSupplier.class)
     static final class Model1 implements IntSupplier {
         @Override
         public int getAsInt() {
@@ -104,7 +104,7 @@ public class ModelAdapterFactory_ImplementationPickerOrderTest {
         }
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class, adapters = IntSupplier.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class, adapters = IntSupplier.class)
     static final class Model2 implements IntSupplier {
         @Override
         public int getAsInt() {

--- a/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_InjectorOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ModelAdapterFactory_InjectorOrderTest.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
@@ -62,7 +62,7 @@ public class ModelAdapterFactory_InjectorOrderTest {
     private BindingsValuesProvidersByContext bindingsValuesProvidersByContext;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
     private Resource resource;
@@ -109,7 +109,7 @@ public class ModelAdapterFactory_InjectorOrderTest {
         assertEquals((Integer) 1, model.getProp1());
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     private interface TestModel {
         @Inject
         Integer getProp1();

--- a/src/test/java/org/apache/sling/models/impl/MultipleInjectorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/MultipleInjectorTest.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 
 import java.util.Arrays;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Source;
@@ -52,7 +52,7 @@ public class MultipleInjectorTest {
     private RequestAttributeInjector attributesInjector;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     private ModelAdapterFactory factory;
 
@@ -111,14 +111,14 @@ public class MultipleInjectorTest {
         factory.createModel(request, ForTwoInjectorsWithInvalidSource.class);
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     public static class ForTwoInjectors {
 
         @Inject
         private String firstAttribute;
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     public static class ForTwoInjectorsWithSource {
 
         @Inject
@@ -126,7 +126,7 @@ public class MultipleInjectorTest {
         private String firstAttribute;
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     public static class ForTwoInjectorsWithInvalidSource {
 
         @Inject

--- a/src/test/java/org/apache/sling/models/impl/OptionalObjectsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/OptionalObjectsTest.java
@@ -20,7 +20,7 @@ package org.apache.sling.models.impl;
 
 import java.util.*;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.scripting.SlingBindings;
@@ -58,7 +58,7 @@ public class OptionalObjectsTest {
     private BundleContext bundleContext;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
     private Logger log;

--- a/src/test/java/org/apache/sling/models/impl/ParameterizedTypeFromRequestAttributeTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ParameterizedTypeFromRequestAttributeTest.java
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Iterator;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.impl.injectors.RequestAttributeInjector;
@@ -42,7 +42,7 @@ public class ParameterizedTypeFromRequestAttributeTest {
     private ModelAdapterFactory factory;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Before
     public void setup() {
@@ -63,7 +63,7 @@ public class ParameterizedTypeFromRequestAttributeTest {
         assertEquals(it, model.getSomeResources());
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     public static class TestModel {
 
         @Inject

--- a/src/test/java/org/apache/sling/models/impl/RequestDisposalTest.java
+++ b/src/test/java/org/apache/sling/models/impl/RequestDisposalTest.java
@@ -19,8 +19,6 @@
 package org.apache.sling.models.impl;
 
 import javax.inject.Inject;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletRequestEvent;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
@@ -30,9 +28,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRequestEvent;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.api.wrappers.SlingJakartaHttpServletRequestWrapper;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.spi.DisposalCallback;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
@@ -60,7 +60,7 @@ public class RequestDisposalTest {
     private Resource resource;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
     private ServletContext servletContext;
@@ -103,12 +103,12 @@ public class RequestDisposalTest {
     @Test
     public void testWithInitializedRequest() {
         // destroy a wrapper of the root request
-        SlingHttpServletRequest destroyedRequest = new SlingHttpServletRequestWrapper(request);
+        SlingJakartaHttpServletRequest destroyedRequest = new SlingJakartaHttpServletRequestWrapper(request);
         factory.requestInitialized(new ServletRequestEvent(servletContext, destroyedRequest));
 
         // but adapt from a wrapper of a wrapper of that wrapper
-        SlingHttpServletRequest adaptableRequest =
-                new SlingHttpServletRequestWrapper(new SlingHttpServletRequestWrapper(destroyedRequest));
+        SlingJakartaHttpServletRequest adaptableRequest =
+                new SlingJakartaHttpServletRequestWrapper(new SlingJakartaHttpServletRequestWrapper(destroyedRequest));
 
         TestModel model = factory.getAdapter(adaptableRequest, TestModel.class);
         assertEquals("teststring", model.testString);
@@ -123,12 +123,12 @@ public class RequestDisposalTest {
     @Test
     public void testTwoInstancesWithInitializedRequest() {
         // destroy a wrapper of the root request
-        SlingHttpServletRequest destroyedRequest = new SlingHttpServletRequestWrapper(request);
+        SlingJakartaHttpServletRequest destroyedRequest = new SlingJakartaHttpServletRequestWrapper(request);
         factory.requestInitialized(new ServletRequestEvent(servletContext, destroyedRequest));
 
         // but adapt from a wrapper of a wrapper of that wrapper
-        SlingHttpServletRequest adaptableRequest =
-                new SlingHttpServletRequestWrapper(new SlingHttpServletRequestWrapper(destroyedRequest));
+        SlingJakartaHttpServletRequest adaptableRequest =
+                new SlingJakartaHttpServletRequestWrapper(new SlingJakartaHttpServletRequestWrapper(destroyedRequest));
 
         TestModel model = factory.getAdapter(adaptableRequest, TestModel.class);
         assertEquals("teststring", model.testString);
@@ -146,11 +146,11 @@ public class RequestDisposalTest {
     @Test
     public void testWithUnitializedRequest() {
         // destroy a wrapper of the root request
-        SlingHttpServletRequest destroyedRequest = new SlingHttpServletRequestWrapper(request);
+        SlingJakartaHttpServletRequest destroyedRequest = new SlingJakartaHttpServletRequestWrapper(request);
 
         // but adapt from a wrapper of a wrapper of that wrapper
-        SlingHttpServletRequest adaptableRequest =
-                new SlingHttpServletRequestWrapper(new SlingHttpServletRequestWrapper(destroyedRequest));
+        SlingJakartaHttpServletRequest adaptableRequest =
+                new SlingJakartaHttpServletRequestWrapper(new SlingJakartaHttpServletRequestWrapper(destroyedRequest));
 
         TestModel model = factory.getAdapter(adaptableRequest, TestModel.class);
         assertEquals("teststring", model.testString);
@@ -174,7 +174,7 @@ public class RequestDisposalTest {
         }
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     public static class TestModel {
 
         @Inject

--- a/src/test/java/org/apache/sling/models/impl/RequestInjectionTest.java
+++ b/src/test/java/org/apache/sling/models/impl/RequestInjectionTest.java
@@ -20,7 +20,7 @@ package org.apache.sling.models.impl;
 
 import java.util.Arrays;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.models.impl.injectors.BindingsInjector;
@@ -44,7 +44,7 @@ public class RequestInjectionTest {
     private ModelAdapterFactory factory;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
     private SlingScriptHelper sling;

--- a/src/test/java/org/apache/sling/models/impl/RequestWrapperTest.java
+++ b/src/test/java/org/apache/sling/models/impl/RequestWrapperTest.java
@@ -23,7 +23,7 @@ import javax.script.ScriptEngineFactory;
 
 import java.util.Collections;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingBindings;
@@ -61,7 +61,7 @@ public class RequestWrapperTest {
     private Resource resource;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @InjectMocks
     private ModelAdapterFactory factory;
@@ -79,7 +79,7 @@ public class RequestWrapperTest {
     @Test
     public void testWrapper() {
         Target expected = new Target();
-        when(adapterManager.getAdapter(any(SlingHttpServletRequest.class), eq(Target.class)))
+        when(adapterManager.getAdapter(any(SlingJakartaHttpServletRequest.class), eq(Target.class)))
                 .thenReturn(expected);
 
         Target actual = factory.getModelFromWrappedRequest(request, resource, Target.class);
@@ -98,10 +98,10 @@ public class RequestWrapperTest {
         };
     }
 
-    private ArgumentMatcher<SlingHttpServletRequest> requestHasResource(final Resource resource) {
-        return new ArgumentMatcher<SlingHttpServletRequest>() {
+    private ArgumentMatcher<SlingJakartaHttpServletRequest> requestHasResource(final Resource resource) {
+        return new ArgumentMatcher<SlingJakartaHttpServletRequest>() {
             @Override
-            public boolean matches(SlingHttpServletRequest slingHttpServletRequest) {
+            public boolean matches(SlingJakartaHttpServletRequest slingHttpServletRequest) {
                 return slingHttpServletRequest.getResource().equals(resource);
             }
         };

--- a/src/test/java/org/apache/sling/models/impl/ResourcePathInjectionTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ResourcePathInjectionTest.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
@@ -57,7 +57,7 @@ public class ResourcePathInjectionTest {
     private Resource adaptableResource;
 
     @Mock
-    SlingHttpServletRequest adaptableRequest;
+    SlingJakartaHttpServletRequest adaptableRequest;
 
     @Mock
     private Resource byPathResource;

--- a/src/test/java/org/apache/sling/models/impl/SelfDependencyTest.java
+++ b/src/test/java/org/apache/sling/models/impl/SelfDependencyTest.java
@@ -20,7 +20,7 @@ package org.apache.sling.models.impl;
 
 import java.util.Collections;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.impl.injectors.SelfInjector;
 import org.apache.sling.models.testmodels.classes.DirectCyclicSelfDependencyModel;
 import org.apache.sling.models.testmodels.classes.IndirectCyclicSelfDependencyModelA;
@@ -47,7 +47,7 @@ public class SelfDependencyTest {
     private ModelAdapterFactory factory;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @SuppressWarnings("unchecked")
     @Before

--- a/src/test/java/org/apache/sling/models/impl/StaticInjectionAPFLoadOrderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/StaticInjectionAPFLoadOrderTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sling.models.impl;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Model;
@@ -49,7 +49,7 @@ public class StaticInjectionAPFLoadOrderTest {
     public OsgiContext context = new OsgiContext();
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
     private ResourceResolver resourceResolver;
@@ -139,7 +139,7 @@ public class StaticInjectionAPFLoadOrderTest {
         return factory.createModel(request, TestModel.class);
     }
 
-    @Model(adaptables = SlingHttpServletRequest.class)
+    @Model(adaptables = SlingJakartaHttpServletRequest.class)
     public static class TestModel {
 
         @SlingObject(injectionStrategy = InjectionStrategy.OPTIONAL)

--- a/src/test/java/org/apache/sling/models/impl/ViaTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ViaTest.java
@@ -21,7 +21,7 @@ package org.apache.sling.models.impl;
 import java.util.Collections;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -50,7 +50,7 @@ public class ViaTest {
     private Resource childResource;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     private ModelAdapterFactory factory;
 
@@ -68,7 +68,7 @@ public class ViaTest {
 
     @Test
     public void testProjectionToResource() {
-        String value = RandomStringUtils.randomAlphanumeric(10);
+        String value = RandomStringUtils.secure().nextAlphanumeric(10);
         ValueMap map = new ValueMapDecorator(Collections.<String, Object>singletonMap("firstProperty", value));
         when(resource.adaptTo(ValueMap.class)).thenReturn(map);
 
@@ -79,7 +79,7 @@ public class ViaTest {
 
     @Test
     public void testProjectionToChildResource() {
-        String value = RandomStringUtils.randomAlphanumeric(10);
+        String value = RandomStringUtils.secure().nextAlphanumeric(10);
         ValueMap map = new ValueMapDecorator(Collections.<String, Object>singletonMap("firstProperty", value));
         when(childResource.adaptTo(ValueMap.class)).thenReturn(map);
         ChildResourceViaModel model = factory.getAdapter(resource, ChildResourceViaModel.class);

--- a/src/test/java/org/apache/sling/models/impl/injectors/ResourcePathInjectorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/injectors/ResourcePathInjectorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.impl.injectors;
+
+import java.lang.reflect.AnnotatedElement;
+
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.wrappers.JakartaToJavaxRequestWrapper;
+import org.apache.sling.models.annotations.injectorspecific.ResourcePath;
+import org.apache.sling.models.spi.DisposalCallbackRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResourcePathInjectorTest {
+
+    private ResourcePathInjector injector = new ResourcePathInjector();
+
+    @Mock
+    private AnnotatedElement element;
+
+    @Mock
+    private DisposalCallbackRegistry registry;
+
+    @Mock
+    private Resource resource;
+
+    @Mock
+    private SlingJakartaHttpServletRequest jakartaRequest;
+
+    @Before
+    public void setUp() {
+        ResourcePath mockResourcePath = Mockito.mock(ResourcePath.class);
+        when(mockResourcePath.path()).thenReturn("/resource1");
+        when(element.getAnnotation(ResourcePath.class)).thenReturn(mockResourcePath);
+
+        ResourceResolver mockRR = mock(ResourceResolver.class);
+        when(mockRR.getResource("/resource1")).thenReturn(resource);
+        when(jakartaRequest.getResourceResolver()).thenReturn(mockRR);
+    }
+
+    @Test
+    public void testResourcePathFromJakartaRequest() {
+        Object result = this.injector.getValue(this.jakartaRequest, null, Resource.class, element, registry);
+        assertEquals(result, this.resource);
+    }
+
+    /**
+     * @deprecated use {@link #testResourcePathFromJakartaRequest()} instead
+     */
+    @Deprecated(since = "2.0.0")
+    @Test
+    public void testResourcePathFromJavaxRequest() {
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                JakartaToJavaxRequestWrapper.toJavaxRequest(this.jakartaRequest);
+        Object result = this.injector.getValue(javaxRequest, null, Resource.class, element, registry);
+        assertEquals(result, this.resource);
+    }
+}

--- a/src/test/java/org/apache/sling/models/impl/injectors/ResourceResolverInjectorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/injectors/ResourceResolverInjectorTest.java
@@ -20,8 +20,8 @@ package org.apache.sling.models.impl.injectors;
 
 import java.lang.reflect.AnnotatedElement;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
@@ -30,8 +30,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * This was a unit test for the ResourceResolverInjector which is now removed
@@ -61,18 +63,34 @@ public class ResourceResolverInjectorTest {
     }
 
     @Test
-    public void testFromRequest() {
-        SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+    public void testFromJakartaRequest() {
+        SlingJakartaHttpServletRequest jakartaRequest = mock(SlingJakartaHttpServletRequest.class);
         ResourceResolver resourceResolver = mock(ResourceResolver.class);
-        when(request.getResourceResolver()).thenReturn(resourceResolver);
+        when(jakartaRequest.getResourceResolver()).thenReturn(resourceResolver);
 
-        Object result = injector.getValue(request, "resourceResolver", ResourceResolver.class, element, registry);
+        Object result =
+                injector.getValue(jakartaRequest, "resourceResolver", ResourceResolver.class, element, registry);
+        assertEquals(resourceResolver, result);
+    }
+
+    /**
+     * @deprecated use {@link #testFromJakartaRequest()} instead
+     */
+    @Deprecated
+    @Test
+    public void testFromJavaxRequest() {
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                mock(org.apache.sling.api.SlingHttpServletRequest.class);
+        ResourceResolver resourceResolver = mock(ResourceResolver.class);
+        when(javaxRequest.getResourceResolver()).thenReturn(resourceResolver);
+
+        Object result = injector.getValue(javaxRequest, "resourceResolver", ResourceResolver.class, element, registry);
         assertEquals(resourceResolver, result);
     }
 
     @Test
     public void testFromSomethingElse() {
-        SlingHttpServletResponse response = mock(SlingHttpServletResponse.class);
+        SlingJakartaHttpServletResponse response = mock(SlingJakartaHttpServletResponse.class);
 
         Object result = injector.getValue(response, "resourceResolver", ResourceResolver.class, element, registry);
         assertNull(result);

--- a/src/test/java/org/apache/sling/models/impl/injectors/SelfInjectorTest.java
+++ b/src/test/java/org/apache/sling/models/impl/injectors/SelfInjectorTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.sling.models.impl.injectors;
 
-import javax.servlet.http.HttpServletRequest;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.wrappers.JakartaToJavaxRequestWrapper;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.Self;
@@ -48,7 +48,7 @@ public class SelfInjectorTest {
     private SelfInjector injector = new SelfInjector();
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
     private AnnotatedElement annotatedElement;
@@ -86,27 +86,57 @@ public class SelfInjectorTest {
     }
 
     @Test
-    public void testMatchingClass() {
+    public void testJakartaMatchingClass() {
         assertSame(
                 request,
                 injector.getValue(
                         request,
                         "notRelevant",
-                        SlingHttpServletRequest.class,
+                        SlingJakartaHttpServletRequest.class,
                         firstConstructorParameter.getAnnotatedElement(),
                         registry));
         assertNull(injector.getValue(
                 request,
                 "notRelevant",
-                SlingHttpServletRequest.class,
+                SlingJakartaHttpServletRequest.class,
                 secondConstructorParameter.getAnnotatedElement(),
                 registry));
-        assertNull(
-                injector.getValue(request, "notRelevant", SlingHttpServletRequest.class, annotatedElement, registry));
+        assertNull(injector.getValue(
+                request, "notRelevant", SlingJakartaHttpServletRequest.class, annotatedElement, registry));
+    }
+
+    /**
+     * @deprecated use {@link #testJakartaMatchingClass()} instead
+     */
+    @Deprecated
+    @Test
+    public void testJavaxMatchingClass() {
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                JakartaToJavaxRequestWrapper.toJavaxRequest(request);
+        assertSame(
+                javaxRequest,
+                injector.getValue(
+                        javaxRequest,
+                        "notRelevant",
+                        org.apache.sling.api.SlingHttpServletRequest.class,
+                        firstConstructorParameter.getAnnotatedElement(),
+                        registry));
+        assertNull(injector.getValue(
+                javaxRequest,
+                "notRelevant",
+                org.apache.sling.api.SlingHttpServletRequest.class,
+                secondConstructorParameter.getAnnotatedElement(),
+                registry));
+        assertNull(injector.getValue(
+                javaxRequest,
+                "notRelevant",
+                org.apache.sling.api.SlingHttpServletRequest.class,
+                annotatedElement,
+                registry));
     }
 
     @Test
-    public void testMatchingSubClass() {
+    public void testJakartaMatchingSubClass() {
         assertSame(
                 request,
                 injector.getValue(
@@ -122,6 +152,32 @@ public class SelfInjectorTest {
                 secondConstructorParameter.getAnnotatedElement(),
                 registry));
         assertNull(injector.getValue(request, "notRelevant", HttpServletRequest.class, annotatedElement, registry));
+    }
+
+    /**
+     * @deprecated use {@link #testJakartaMatchingSubClass()} instead
+     */
+    @Deprecated
+    @Test
+    public void testJavaxMatchingSubClass() {
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                JakartaToJavaxRequestWrapper.toJavaxRequest(request);
+        assertSame(
+                javaxRequest,
+                injector.getValue(
+                        javaxRequest,
+                        "notRelevant",
+                        javax.servlet.http.HttpServletRequest.class,
+                        firstConstructorParameter.getAnnotatedElement(),
+                        registry));
+        assertNull(injector.getValue(
+                javaxRequest,
+                "notRelevant",
+                javax.servlet.http.HttpServletRequest.class,
+                secondConstructorParameter.getAnnotatedElement(),
+                registry));
+        assertNull(injector.getValue(
+                javaxRequest, "notRelevant", javax.servlet.http.HttpServletRequest.class, annotatedElement, registry));
     }
 
     @Test
@@ -142,30 +198,74 @@ public class SelfInjectorTest {
     }
 
     @Test
-    public void testWithNullName() {
+    public void testJakartaWithNullName() {
         assertSame(
                 request,
                 injector.getValue(
                         request,
                         null,
-                        SlingHttpServletRequest.class,
+                        SlingJakartaHttpServletRequest.class,
                         firstConstructorParameter.getAnnotatedElement(),
                         registry));
         assertNull(injector.getValue(
                 request,
                 null,
-                SlingHttpServletRequest.class,
+                SlingJakartaHttpServletRequest.class,
                 secondConstructorParameter.getAnnotatedElement(),
                 registry));
-        assertNull(injector.getValue(request, null, SlingHttpServletRequest.class, annotatedElement, registry));
+        assertNull(injector.getValue(request, null, SlingJakartaHttpServletRequest.class, annotatedElement, registry));
+    }
+
+    /**
+     * @deprecated use {@link #testJakartaWithNullName()} instead
+     */
+    @Deprecated
+    @Test
+    public void testJavaxWithNullName() {
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                JakartaToJavaxRequestWrapper.toJavaxRequest(request);
+        assertSame(
+                javaxRequest,
+                injector.getValue(
+                        javaxRequest,
+                        null,
+                        org.apache.sling.api.SlingHttpServletRequest.class,
+                        firstConstructorParameter.getAnnotatedElement(),
+                        registry));
+        assertNull(injector.getValue(
+                javaxRequest,
+                null,
+                org.apache.sling.api.SlingHttpServletRequest.class,
+                secondConstructorParameter.getAnnotatedElement(),
+                registry));
+        assertNull(injector.getValue(
+                javaxRequest, null, org.apache.sling.api.SlingHttpServletRequest.class, annotatedElement, registry));
     }
 
     @Test
-    public void testMatchingClassWithSelfAnnotation() {
+    public void testJakartaMatchingClassWithSelfAnnotation() {
         when(annotatedElement.isAnnotationPresent(Self.class)).thenReturn(true);
-        Object result =
-                injector.getValue(request, "notRelevant", SlingHttpServletRequest.class, annotatedElement, registry);
+        Object result = injector.getValue(
+                request, "notRelevant", SlingJakartaHttpServletRequest.class, annotatedElement, registry);
         assertSame(request, result);
+    }
+
+    /**
+     * @deprecated use {@link #testJakartaMatchingClassWithSelfAnnotation()} instead
+     */
+    @Deprecated
+    @Test
+    public void testJavaxMatchingClassWithSelfAnnotation() {
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                JakartaToJavaxRequestWrapper.toJavaxRequest(request);
+        when(annotatedElement.isAnnotationPresent(Self.class)).thenReturn(true);
+        Object result = injector.getValue(
+                javaxRequest,
+                "notRelevant",
+                org.apache.sling.api.SlingHttpServletRequest.class,
+                annotatedElement,
+                registry);
+        assertSame(javaxRequest, result);
     }
 
     @Test

--- a/src/test/java/org/apache/sling/models/impl/injectors/SlingObjectInjectorRequestTest.java
+++ b/src/test/java/org/apache/sling/models/impl/injectors/SlingObjectInjectorRequestTest.java
@@ -18,17 +18,19 @@
  */
 package org.apache.sling.models.impl.injectors;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.lang.reflect.AnnotatedElement;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.felix.http.javaxwrappers.HttpServletRequestWrapper;
+import org.apache.felix.http.javaxwrappers.HttpServletResponseWrapper;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.api.wrappers.JakartaToJavaxResponseWrapper;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
 import org.junit.Before;
@@ -37,8 +39,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SlingObjectInjectorRequestTest {
@@ -49,10 +53,10 @@ public class SlingObjectInjectorRequestTest {
     private AnnotatedElement annotatedElement;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Mock
-    private SlingHttpServletResponse response;
+    private SlingJakartaHttpServletResponse response;
 
     @Mock
     private SlingScriptHelper scriptHelper;
@@ -73,7 +77,8 @@ public class SlingObjectInjectorRequestTest {
         when(this.request.getResourceResolver()).thenReturn(this.resourceResolver);
         when(this.request.getResource()).thenReturn(this.resource);
         when(this.request.getAttribute(SlingBindings.class.getName())).thenReturn(bindings);
-        when(this.scriptHelper.getResponse()).thenReturn(this.response);
+        when(this.scriptHelper.getResponse()).thenReturn(JakartaToJavaxResponseWrapper.toJavaxResponse(this.response));
+        when(this.scriptHelper.getJakartaResponse()).thenReturn(this.response);
     }
 
     @Test
@@ -94,19 +99,61 @@ public class SlingObjectInjectorRequestTest {
     }
 
     @Test
-    public void testRequest() {
+    public void testJakartaRequest() {
         Object result = this.injector.getValue(
-                this.request, null, SlingHttpServletRequest.class, this.annotatedElement, registry);
+                this.request, null, SlingJakartaHttpServletRequest.class, this.annotatedElement, registry);
         assertSame(this.request, result);
 
         result = this.injector.getValue(this.request, null, HttpServletRequest.class, this.annotatedElement, registry);
         assertSame(this.request, result);
     }
 
+    /**
+     * @deprecated use {@link #testJakartaResponse()} instead
+     */
+    @Deprecated(since = "2.0.0")
     @Test
-    public void testResponse() {
+    public void testJavaxResponse() {
         Object result = this.injector.getValue(
-                this.request, null, SlingHttpServletResponse.class, this.annotatedElement, registry);
+                this.request,
+                null,
+                org.apache.sling.api.SlingHttpServletResponse.class,
+                this.annotatedElement,
+                registry);
+        assertTrue(result instanceof HttpServletResponseWrapper);
+        assertSame(this.response, ((HttpServletResponseWrapper) result).getResponse());
+
+        result = this.injector.getValue(
+                this.request, null, javax.servlet.http.HttpServletResponse.class, this.annotatedElement, registry);
+        assertTrue(result instanceof HttpServletResponseWrapper);
+        assertSame(this.response, ((HttpServletResponseWrapper) result).getResponse());
+    }
+
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated(since = "2.0.0")
+    @Test
+    public void testJavaxRequest() {
+        Object result = this.injector.getValue(
+                this.request,
+                null,
+                org.apache.sling.api.SlingHttpServletRequest.class,
+                this.annotatedElement,
+                registry);
+        assertTrue(result instanceof HttpServletRequestWrapper);
+        assertSame(this.request, ((HttpServletRequestWrapper) result).getRequest());
+
+        result = this.injector.getValue(
+                this.request, null, javax.servlet.http.HttpServletRequest.class, this.annotatedElement, registry);
+        assertTrue(result instanceof HttpServletRequestWrapper);
+        assertSame(this.request, ((HttpServletRequestWrapper) result).getRequest());
+    }
+
+    @Test
+    public void testJakartaResponse() {
+        Object result = this.injector.getValue(
+                this.request, null, SlingJakartaHttpServletResponse.class, this.annotatedElement, registry);
         assertSame(this.response, result);
 
         result = this.injector.getValue(this.request, null, HttpServletResponse.class, this.annotatedElement, registry);

--- a/src/test/java/org/apache/sling/models/impl/injectors/SlingObjectInjectorResourceResolverTest.java
+++ b/src/test/java/org/apache/sling/models/impl/injectors/SlingObjectInjectorResourceResolverTest.java
@@ -20,7 +20,8 @@ package org.apache.sling.models.impl.injectors;
 
 import java.lang.reflect.AnnotatedElement;
 
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.scripting.SlingScriptHelper;
@@ -61,17 +62,47 @@ public class SlingObjectInjectorResourceResolverTest {
         assertNull(result);
     }
 
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated(since = "2.0.0")
     @Test
-    public void testRequest() {
+    public void testJavaxRequest() {
         Object result = this.injector.getValue(
-                this.resourceResolver, null, SlingHttpServletResponse.class, this.annotatedElement, registry);
+                this.resourceResolver,
+                null,
+                org.apache.sling.api.SlingHttpServletRequest.class,
+                this.annotatedElement,
+                registry);
+        assertNull(result);
+    }
+
+    /**
+     * @deprecated use {@link #testJakartaResponse()} instead
+     */
+    @Deprecated(since = "2.0.0")
+    @Test
+    public void testJavaxResponse() {
+        Object result = this.injector.getValue(
+                this.resourceResolver,
+                null,
+                org.apache.sling.api.SlingHttpServletResponse.class,
+                this.annotatedElement,
+                registry);
         assertNull(result);
     }
 
     @Test
-    public void testResponse() {
+    public void testJakartaRequest() {
         Object result = this.injector.getValue(
-                this.resourceResolver, null, SlingHttpServletResponse.class, this.annotatedElement, registry);
+                this.resourceResolver, null, SlingJakartaHttpServletRequest.class, this.annotatedElement, registry);
+        assertNull(result);
+    }
+
+    @Test
+    public void testJakartaResponse() {
+        Object result = this.injector.getValue(
+                this.resourceResolver, null, SlingJakartaHttpServletResponse.class, this.annotatedElement, registry);
         assertNull(result);
     }
 

--- a/src/test/java/org/apache/sling/models/impl/injectors/SlingObjectInjectorResourceTest.java
+++ b/src/test/java/org/apache/sling/models/impl/injectors/SlingObjectInjectorResourceTest.java
@@ -20,7 +20,8 @@ package org.apache.sling.models.impl.injectors;
 
 import java.lang.reflect.AnnotatedElement;
 
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.scripting.SlingScriptHelper;
@@ -75,17 +76,47 @@ public class SlingObjectInjectorResourceTest {
         assertSame(resource, result);
     }
 
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated(since = "2.0.0")
     @Test
-    public void testRequest() {
+    public void testJavaxRequest() {
         Object result = this.injector.getValue(
-                this.resource, null, SlingHttpServletResponse.class, this.annotatedElement, registry);
+                this.resource,
+                null,
+                org.apache.sling.api.SlingHttpServletRequest.class,
+                this.annotatedElement,
+                registry);
+        assertNull(result);
+    }
+
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated(since = "2.0.0")
+    @Test
+    public void testJavaxResponse() {
+        Object result = this.injector.getValue(
+                this.resource,
+                null,
+                org.apache.sling.api.SlingHttpServletResponse.class,
+                this.annotatedElement,
+                registry);
         assertNull(result);
     }
 
     @Test
-    public void testResponse() {
+    public void testJakartaRequest() {
         Object result = this.injector.getValue(
-                this.resource, null, SlingHttpServletResponse.class, this.annotatedElement, registry);
+                this.resource, null, SlingJakartaHttpServletRequest.class, this.annotatedElement, registry);
+        assertNull(result);
+    }
+
+    @Test
+    public void testJakartaResponse() {
+        Object result = this.injector.getValue(
+                this.resource, null, SlingJakartaHttpServletResponse.class, this.annotatedElement, registry);
         assertNull(result);
     }
 

--- a/src/test/java/org/apache/sling/models/impl/via/ChildResourceViaProviderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/via/ChildResourceViaProviderTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.models.impl.via;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,12 +42,20 @@ public class ChildResourceViaProviderTest {
     private Resource childResource;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest jakartaRequest;
+
+    /**
+     * @deprecated use {@link #jakartaRequest} instead
+     */
+    @Deprecated
+    @Mock
+    private SlingHttpServletRequest javaxRequest;
 
     @Before
     public void init() {
         when(resource.getChild("child")).thenReturn(childResource);
-        when(request.getResource()).thenReturn(resource);
+        when(jakartaRequest.getResource()).thenReturn(resource);
+        when(javaxRequest.getResource()).thenReturn(resource);
     }
 
     @Test
@@ -56,8 +65,19 @@ public class ChildResourceViaProviderTest {
     }
 
     @Test
-    public void testRequest() {
-        Object adaptable = provider.getAdaptable(request, "child");
+    public void testJakartaRequest() {
+        Object adaptable = provider.getAdaptable(jakartaRequest, "child");
+        Resource adaptableResource = ((SlingJakartaHttpServletRequest) adaptable).getResource();
+        Assert.assertEquals(adaptableResource, childResource);
+    }
+
+    /**
+     * @deprecated use {@link #testJakartaRequest()} instead
+     */
+    @Deprecated
+    @Test
+    public void testJavaxRequest() {
+        Object adaptable = provider.getAdaptable(javaxRequest, "child");
         Resource adaptableResource = ((SlingHttpServletRequest) adaptable).getResource();
         Assert.assertEquals(adaptableResource, childResource);
     }

--- a/src/test/java/org/apache/sling/models/impl/via/OriginalResourceTypeViaProviderTest.java
+++ b/src/test/java/org/apache/sling/models/impl/via/OriginalResourceTypeViaProviderTest.java
@@ -18,10 +18,11 @@
  */
 package org.apache.sling.models.impl.via;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceWrapper;
-import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.api.wrappers.JakartaToJavaxRequestWrapper;
+import org.apache.sling.api.wrappers.SlingJakartaHttpServletRequestWrapper;
 import org.apache.sling.models.annotations.via.OriginalResourceType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,7 +41,7 @@ public class OriginalResourceTypeViaProviderTest {
     private Resource resource;
 
     @Mock
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Test
     public void testReturnsCorrectMarkerInterface() {
@@ -80,17 +81,39 @@ public class OriginalResourceTypeViaProviderTest {
     }
 
     @Test
-    public void testUnwrapsRequest() {
+    public void testUnwrapsJakartaRequest() {
         // once
-        SlingHttpServletRequest testCase = new ResourceTypeForcingRequestWrapper(request, resource, "foo");
+        SlingJakartaHttpServletRequest testCase =
+                new ResourceTypeForcingJakartaRequestWrapper(request, resource, "foo");
         Object projected = provider.getAdaptable(testCase, null);
         assertEquals(request, projected);
+
+        // more than once
+        testCase = new ResourceTypeForcingJakartaRequestWrapper(testCase, resource, "bar");
+        testCase = new ResourceTypeForcingJakartaRequestWrapper(testCase, resource, "foobar");
+        projected = provider.getAdaptable(testCase, null);
+        assertEquals(request, projected);
+    }
+
+    /**
+     * @deprecated use {@link #testUnwrapsJakartaRequest()} instead
+     */
+    @Deprecated
+    @Test
+    public void testUnwrapsJavaxRequest() {
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                JakartaToJavaxRequestWrapper.toJavaxRequest(request);
+        // once
+        org.apache.sling.api.SlingHttpServletRequest testCase =
+                new ResourceTypeForcingRequestWrapper(javaxRequest, resource, "foo");
+        Object projected = provider.getAdaptable(testCase, null);
+        assertEquals(javaxRequest, projected);
 
         // more than once
         testCase = new ResourceTypeForcingRequestWrapper(testCase, resource, "bar");
         testCase = new ResourceTypeForcingRequestWrapper(testCase, resource, "foobar");
         projected = provider.getAdaptable(testCase, null);
-        assertEquals(request, projected);
+        assertEquals(javaxRequest, projected);
     }
 
     @Test
@@ -101,8 +124,22 @@ public class OriginalResourceTypeViaProviderTest {
     }
 
     @Test
-    public void testDoesNotUnwrapOtherRequestWrappers() {
-        SlingHttpServletRequest testCase = new SlingHttpServletRequestWrapper(request);
+    public void testDoesNotUnwrapOtherJakartaRequestWrappers() {
+        SlingJakartaHttpServletRequest testCase = new SlingJakartaHttpServletRequestWrapper(request);
+        Object projected = provider.getAdaptable(testCase, null);
+        assertEquals(testCase, projected);
+    }
+
+    /**
+     * @deprecated use {@link #testDoesNotUnwrapOtherJakartaRequestWrappers()} instead
+     */
+    @Deprecated
+    @Test
+    public void testDoesNotUnwrapOtherJavaxRequestWrappers() {
+        org.apache.sling.api.SlingHttpServletRequest javaxRequest =
+                JakartaToJavaxRequestWrapper.toJavaxRequest(request);
+        org.apache.sling.api.SlingHttpServletRequest testCase =
+                new org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper(javaxRequest);
         Object projected = provider.getAdaptable(testCase, null);
         assertEquals(testCase, projected);
     }

--- a/src/test/java/org/apache/sling/models/testmodels/classes/BindingsModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/BindingsModel.java
@@ -21,12 +21,12 @@ package org.apache.sling.models.testmodels.classes;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.models.annotations.Model;
 import org.slf4j.Logger;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class BindingsModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/CachedModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/CachedModel.java
@@ -20,12 +20,12 @@ package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 
 @Model(
-        adaptables = {SlingHttpServletRequest.class, Resource.class},
+        adaptables = {SlingJakartaHttpServletRequest.class, Resource.class},
         cache = true)
 public class CachedModel {
 

--- a/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithAdapterTypes12.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithAdapterTypes12.java
@@ -18,13 +18,13 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.testmodels.interfaces.AdapterType1;
 import org.apache.sling.models.testmodels.interfaces.AdapterType2;
 
 @Model(
-        adaptables = SlingHttpServletRequest.class,
+        adaptables = SlingJakartaHttpServletRequest.class,
         adapters = {AdapterType1.class, AdapterType2.class},
         cache = true)
 public class CachedModelWithAdapterTypes12 implements AdapterType1, AdapterType2 {}

--- a/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithAdapterTypes23.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithAdapterTypes23.java
@@ -18,13 +18,13 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.testmodels.interfaces.AdapterType2;
 import org.apache.sling.models.testmodels.interfaces.AdapterType3;
 
 @Model(
-        adaptables = SlingHttpServletRequest.class,
+        adaptables = SlingJakartaHttpServletRequest.class,
         adapters = {AdapterType2.class, AdapterType3.class},
         cache = true)
 public class CachedModelWithAdapterTypes23 implements AdapterType2, AdapterType3 {}

--- a/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithSelfReference.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/CachedModelWithSelfReference.java
@@ -18,18 +18,18 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
-@Model(adaptables = SlingHttpServletRequest.class, cache = true)
+@Model(adaptables = SlingJakartaHttpServletRequest.class, cache = true)
 public class CachedModelWithSelfReference {
     // This can be tuned to make it run faster or slower.
     // The larger this is, the fewer number of instances needed to test.
     public static int numberOfLongs = 4000;
 
     @Self
-    SlingHttpServletRequest request;
+    SlingJakartaHttpServletRequest request;
 
     // Add a big array of longs to the class, to make it take fewer iterations to fill the heap
     public long[] longs = new long[numberOfLongs];

--- a/src/test/java/org/apache/sling/models/testmodels/classes/DirectCyclicSelfDependencyModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/DirectCyclicSelfDependencyModel.java
@@ -18,11 +18,11 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class DirectCyclicSelfDependencyModel {
 
     @Self

--- a/src/test/java/org/apache/sling/models/testmodels/classes/IndirectCyclicSelfDependencyModelA.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/IndirectCyclicSelfDependencyModelA.java
@@ -18,11 +18,11 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class IndirectCyclicSelfDependencyModelA {
 
     @Self

--- a/src/test/java/org/apache/sling/models/testmodels/classes/IndirectCyclicSelfDependencyModelB.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/IndirectCyclicSelfDependencyModelB.java
@@ -18,11 +18,11 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class IndirectCyclicSelfDependencyModelB {
 
     @Self

--- a/src/test/java/org/apache/sling/models/testmodels/classes/InjectorSpecificAnnotationModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/InjectorSpecificAnnotationModel.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.models.annotations.Model;
@@ -29,7 +29,7 @@ import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.slf4j.Logger;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class InjectorSpecificAnnotationModel {
 
     @ValueMapValue(optional = true)

--- a/src/test/java/org/apache/sling/models/testmodels/classes/InvalidConstructorModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/InvalidConstructorModel.java
@@ -19,12 +19,12 @@
 package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletResponse;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class InvalidConstructorModel {
 
     private HttpServletResponse response;

--- a/src/test/java/org/apache/sling/models/testmodels/classes/OptionalObjectsModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/OptionalObjectsModel.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.models.annotations.Model;
@@ -34,7 +34,7 @@ import org.apache.sling.models.annotations.injectorspecific.RequestAttribute;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.slf4j.Logger;
 
-@Model(adaptables = {Resource.class, SlingHttpServletRequest.class})
+@Model(adaptables = {Resource.class, SlingJakartaHttpServletRequest.class})
 public class OptionalObjectsModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/RequestOSGiModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/RequestOSGiModel.java
@@ -20,11 +20,11 @@ package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.testmodels.interfaces.ServiceInterface;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class RequestOSGiModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/ResourcePathAllOptionalModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/ResourcePathAllOptionalModel.java
@@ -21,14 +21,14 @@ package org.apache.sling.models.testmodels.classes;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.Path;
 import org.apache.sling.models.annotations.injectorspecific.ResourcePath;
 
-@Model(adaptables = {Resource.class, SlingHttpServletRequest.class})
+@Model(adaptables = {Resource.class, SlingJakartaHttpServletRequest.class})
 public class ResourcePathAllOptionalModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/ResourcePathModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/ResourcePathModel.java
@@ -23,13 +23,13 @@ import javax.inject.Named;
 
 import java.util.List;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Path;
 import org.apache.sling.models.annotations.injectorspecific.ResourcePath;
 
-@Model(adaptables = {Resource.class, SlingHttpServletRequest.class})
+@Model(adaptables = {Resource.class, SlingJakartaHttpServletRequest.class})
 public class ResourcePathModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/ResourcePathModelWrapping.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/ResourcePathModelWrapping.java
@@ -18,12 +18,12 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.ResourcePath;
 
-@Model(adaptables = {Resource.class, SlingHttpServletRequest.class})
+@Model(adaptables = {Resource.class, SlingJakartaHttpServletRequest.class})
 public class ResourcePathModelWrapping {
 
     @ResourcePath(path = "/some/path")

--- a/src/test/java/org/apache/sling/models/testmodels/classes/ResourcePathPartialModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/ResourcePathPartialModel.java
@@ -20,7 +20,7 @@ package org.apache.sling.models.testmodels.classes;
 
 import java.util.List;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
@@ -28,7 +28,7 @@ import org.apache.sling.models.annotations.Required;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.ResourcePath;
 
-@Model(adaptables = {Resource.class, SlingHttpServletRequest.class})
+@Model(adaptables = {Resource.class, SlingJakartaHttpServletRequest.class})
 public class ResourcePathPartialModel {
 
     @ResourcePath(name = "propertyWithSeveralPaths", injectionStrategy = InjectionStrategy.REQUIRED)

--- a/src/test/java/org/apache/sling/models/testmodels/classes/SelfDependencyModelA.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/SelfDependencyModelA.java
@@ -18,11 +18,11 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class SelfDependencyModelA {
 
     @Self

--- a/src/test/java/org/apache/sling/models/testmodels/classes/SelfDependencyModelB.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/SelfDependencyModelB.java
@@ -18,17 +18,17 @@
  */
 package org.apache.sling.models.testmodels.classes;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class SelfDependencyModelB {
 
     @Self
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
-    public SlingHttpServletRequest getRequest() {
+    public SlingJakartaHttpServletRequest getRequest() {
         return request;
     }
 }

--- a/src/test/java/org/apache/sling/models/testmodels/classes/SuperclassConstructorModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/SuperclassConstructorModel.java
@@ -19,12 +19,12 @@
 package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class SuperclassConstructorModel {
 
     private HttpServletRequest request;

--- a/src/test/java/org/apache/sling/models/testmodels/classes/UncachedModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/UncachedModel.java
@@ -20,11 +20,11 @@ package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+@Model(adaptables = {SlingJakartaHttpServletRequest.class, Resource.class})
 public class UncachedModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/ViaModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/ViaModel.java
@@ -20,11 +20,11 @@ package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Via;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class ViaModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/WithOneConstructorModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/WithOneConstructorModel.java
@@ -20,18 +20,18 @@ package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class WithOneConstructorModel {
 
-    private final SlingHttpServletRequest request;
+    private final SlingJakartaHttpServletRequest request;
 
     @Inject
     private int attribute;
 
-    public WithOneConstructorModel(SlingHttpServletRequest request) {
+    public WithOneConstructorModel(SlingJakartaHttpServletRequest request) {
         this.request = request;
     }
 
@@ -39,7 +39,7 @@ public class WithOneConstructorModel {
         return attribute;
     }
 
-    public SlingHttpServletRequest getRequest() {
+    public SlingJakartaHttpServletRequest getRequest() {
         return request;
     }
 }

--- a/src/test/java/org/apache/sling/models/testmodels/classes/WithThreeConstructorsModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/WithThreeConstructorsModel.java
@@ -20,26 +20,27 @@ package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class WithThreeConstructorsModel {
 
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
-    private SlingHttpServletResponse response;
+    private SlingJakartaHttpServletResponse response;
 
     @Inject
     private int attribute;
 
-    public WithThreeConstructorsModel(SlingHttpServletRequest request, SlingHttpServletResponse response) {
+    public WithThreeConstructorsModel(
+            SlingJakartaHttpServletRequest request, SlingJakartaHttpServletResponse response) {
         this.request = request;
         this.response = response;
     }
 
-    public WithThreeConstructorsModel(SlingHttpServletRequest request) {
+    public WithThreeConstructorsModel(SlingJakartaHttpServletRequest request) {
         this.request = request;
     }
 
@@ -49,11 +50,11 @@ public class WithThreeConstructorsModel {
         return attribute;
     }
 
-    public SlingHttpServletRequest getRequest() {
+    public SlingJakartaHttpServletRequest getRequest() {
         return request;
     }
 
-    public SlingHttpServletResponse getResponse() {
+    public SlingJakartaHttpServletResponse getResponse() {
         return response;
     }
 }

--- a/src/test/java/org/apache/sling/models/testmodels/classes/WithTwoConstructorsModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/WithTwoConstructorsModel.java
@@ -20,18 +20,18 @@ package org.apache.sling.models.testmodels.classes;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class WithTwoConstructorsModel {
 
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Inject
     private int attribute;
 
-    public WithTwoConstructorsModel(SlingHttpServletRequest request) {
+    public WithTwoConstructorsModel(SlingJakartaHttpServletRequest request) {
         this.request = request;
     }
 
@@ -41,7 +41,7 @@ public class WithTwoConstructorsModel {
         return attribute;
     }
 
-    public SlingHttpServletRequest getRequest() {
+    public SlingJakartaHttpServletRequest getRequest() {
         return request;
     }
 }

--- a/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/BindingsModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/BindingsModel.java
@@ -21,12 +21,12 @@ package org.apache.sling.models.testmodels.classes.constructorinjection;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.models.annotations.Model;
 import org.slf4j.Logger;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class BindingsModel {
 
     private final SlingScriptHelper sling;

--- a/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/InjectorSpecificAnnotationModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/InjectorSpecificAnnotationModel.java
@@ -20,7 +20,7 @@ package org.apache.sling.models.testmodels.classes.constructorinjection;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.models.annotations.Model;
@@ -31,7 +31,7 @@ import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.slf4j.Logger;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class InjectorSpecificAnnotationModel {
 
     private final String first;

--- a/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/NoNameModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/NoNameModel.java
@@ -20,11 +20,11 @@ package org.apache.sling.models.testmodels.classes.constructorinjection;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class NoNameModel {
 
     private final SlingScriptHelper sling;

--- a/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/ViaRequestSuffixModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/ViaRequestSuffixModel.java
@@ -20,11 +20,11 @@ package org.apache.sling.models.testmodels.classes.constructorinjection;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Via;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class ViaRequestSuffixModel {
 
     private final String suffix;

--- a/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/WithThreeConstructorsOneInjectModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/constructorinjection/WithThreeConstructorsOneInjectModel.java
@@ -21,20 +21,20 @@ package org.apache.sling.models.testmodels.classes.constructorinjection;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class WithThreeConstructorsOneInjectModel {
 
-    private SlingHttpServletRequest request;
+    private SlingJakartaHttpServletRequest request;
 
     @Inject
     private int attribute;
 
     private String attribute2;
 
-    public WithThreeConstructorsOneInjectModel(SlingHttpServletRequest request) {
+    public WithThreeConstructorsOneInjectModel(SlingJakartaHttpServletRequest request) {
         this.request = request;
     }
 
@@ -53,7 +53,7 @@ public class WithThreeConstructorsOneInjectModel {
         return attribute2;
     }
 
-    public SlingHttpServletRequest getRequest() {
+    public SlingJakartaHttpServletRequest getRequest() {
         return request;
     }
 }

--- a/src/test/java/org/apache/sling/models/testmodels/classes/constructorvisibility/PrivateConstructorModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/constructorvisibility/PrivateConstructorModel.java
@@ -20,10 +20,10 @@ package org.apache.sling.models.testmodels.classes.constructorvisibility;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class PrivateConstructorModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/classes/constructorvisibility/ProtectedConstructorModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/constructorvisibility/ProtectedConstructorModel.java
@@ -20,10 +20,10 @@ package org.apache.sling.models.testmodels.classes.constructorvisibility;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class ProtectedConstructorModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/interfaces/CachedModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/interfaces/CachedModel.java
@@ -20,10 +20,10 @@ package org.apache.sling.models.testmodels.interfaces;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class, cache = true)
+@Model(adaptables = SlingJakartaHttpServletRequest.class, cache = true)
 public interface CachedModel {
 
     @Inject

--- a/src/test/java/org/apache/sling/models/testmodels/interfaces/UncachedModel.java
+++ b/src/test/java/org/apache/sling/models/testmodels/interfaces/UncachedModel.java
@@ -20,10 +20,10 @@ package org.apache.sling.models.testmodels.interfaces;
 
 import javax.inject.Inject;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public interface UncachedModel {
 
     @Inject


### PR DESCRIPTION
bump bundle major version to 2.0.0
bump minimum java version to 17

bump models.api to 2.0.0-SNAPSHOT (see [SLING-12874](https://issues.apache.org/jira/browse/SLING-12874))
bump sling api to 3.x
bump slf4j-api to the 2.x version
bump org.apache.sling.scripting.core to 3.0.0
bump org.apache.sling.servlet-helpers to 2.0.0-SNAPSHOT (see [SLING-12858](https://issues.apache.org/jira/browse/SLING-12858))

migrate the javax.servlet references in non-pubic classes to jakarta.servlet
deprecate the public methods that used SlingHttpServletRequest