### PR TITLE
SLING-13143 - Missing optional interface dependency causes NoClassDefFoundError and stops initialising other models

### DIFF
--- a/src/main/java/org/apache/sling/models/impl/ModelPackageBundleListener.java
+++ b/src/main/java/org/apache/sling/models/impl/ModelPackageBundleListener.java
@@ -193,7 +193,7 @@ public class ModelPackageBundleListener implements BundleTrackerCustomizer<Servi
                     }
                 }
             }
-        } catch (ClassNotFoundException | AnnotationFormatError e) {
+        } catch (NoClassDefFoundError | ClassNotFoundException | AnnotationFormatError e) {
             log.warn(
                     "Unable to load class '{}' from bundle '{}': {}",
                     className,

--- a/src/test/java/org/apache/sling/models/impl/ModelPackageBundleListenerTest.java
+++ b/src/test/java/org/apache/sling/models/impl/ModelPackageBundleListenerTest.java
@@ -103,6 +103,22 @@ class ModelPackageBundleListenerTest {
                 "Model should not yet have been registered but was");
     }
 
+    @Test
+    void testAddingBundleWithLinkageError() throws ClassNotFoundException {
+        ClassLoader classLoader = new HideClassesClassLoader(
+                this.getClass().getClassLoader(),
+                org.apache.sling.models.testmodels.classes.MissingClass.class.getName());
+
+        ModelPackageBundleListener listener = createListenerForBundleWithClass(
+                classLoader, org.apache.sling.models.testmodels.classes.ClassWithMissingClass.class.getName());
+
+        listener.addingBundle(mockBundle, new BundleEvent(BundleEvent.STARTED, mockBundle));
+        assertFalse(
+                adapterImplementations.isModelClass(
+                        org.apache.sling.models.testmodels.classes.ClassWithMissingClass.class),
+                "Model should not yet have been registered but was");
+    }
+
     private ModelPackageBundleListener createListenerForBundleWithClass(Class<?> modelClass)
             throws ClassNotFoundException {
         return createListenerForBundleWithClass(modelClass.getClassLoader(), modelClass.getName());

--- a/src/test/java/org/apache/sling/models/testmodels/classes/ClassWithMissingClass.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/ClassWithMissingClass.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.testmodels.classes;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = Resource.class)
+public class ClassWithMissingClass implements MissingClass {}

--- a/src/test/java/org/apache/sling/models/testmodels/classes/MissingClass.java
+++ b/src/test/java/org/apache/sling/models/testmodels/classes/MissingClass.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.testmodels.classes;
+
+public interface MissingClass {}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-13143 

> The issue is nearly identical to [SLING-6764](https://issues.apache.org/jira/browse/SLING-6764), but specifically triggered by a NoClassDefFoundError when an implementation class is present, but an interface it implements is missing at runtime.
> 
> Context: This scenario occurs when dependencies are marked as optional (present during compilation but missing in specific runtime environments). While the absence of the model itself is expected in these environments, it currently prevents other valid models from being initialized.
> 
> Steps to reproduce:
> 
> Define a Sling Model that implements an interface from an optional dependency.
> Deploy the bundle to an environment where the optional dependency (the interface) is missing.
> Observe that NoClassDefFoundError is thrown during the scanning/registration process.
> 
> Observed Behavior: The NoClassDefFoundError is not caught by the injector/registrar, causing a failure that halts the initialization of other models.
> 
> Expected Behavior: Similar to the fix in [SLING-6764](https://issues.apache.org/jira/browse/SLING-6764), NoClassDefFoundError should be caught and logged as a warning/error. The failure to load one model due to missing optional dependencies should not impact the availability of other models in the system.