### PR TITLE
SLING-12217 : Reduce resource lookups in Sling Model resolution

### DIFF
--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -316,10 +316,33 @@ final class AdapterImplementations {
         return getModelClassForResource(resource, resourceTypeMappingsForResources);
     }
 
-    @SuppressWarnings("unchecked")
-    private static Map<Map<String, Class<?>>, Map<String, Object>> getModelClassCache(final ResourceResolver resolver) {
-        return (Map<Map<String, Class<?>>, Map<String, Object>>)
-                resolver.getPropertyMap().get(CACHE_KEY);
+    /**
+     * Encapsulates the nested map structure to simplify the caching logic.
+     * Methods are synchronized to prevent bucket corruption during multi-threaded integration tests
+     * that share a mocked ResourceResolver.
+     */
+    private static class RequestModelClassCache {
+        private final Map<Map<String, Class<?>>, Map<String, Object>> cache = new java.util.IdentityHashMap<>();
+
+        public synchronized Object get(Map<String, Class<?>> registryMap, String resourceType) {
+            Map<String, Object> innerCache = cache.get(registryMap);
+            return innerCache != null ? innerCache.get(resourceType) : null;
+        }
+
+        public synchronized void put(Map<String, Class<?>> registryMap, String resourceType, Class<?> modelClass) {
+            Map<String, Object> innerCache = cache.computeIfAbsent(registryMap, k -> new java.util.HashMap<>());
+            innerCache.put(resourceType, modelClass == null ? Object.class : modelClass);
+        }
+    }
+
+    private static RequestModelClassCache getModelClassCache(final ResourceResolver resolver) {
+        RequestModelClassCache cache =
+                (RequestModelClassCache) resolver.getPropertyMap().get(CACHE_KEY);
+        if (cache == null) {
+            cache = new RequestModelClassCache();
+            resolver.getPropertyMap().put(CACHE_KEY, cache);
+        }
+        return cache;
     }
 
     protected static Class<?> getModelClassForResource(final Resource resource, final Map<String, Class<?>> map) {
@@ -332,23 +355,16 @@ final class AdapterImplementations {
             return null;
         }
 
-        Map<Map<String, Class<?>>, Map<String, Object>> cache = getModelClassCache(resolver);
+        RequestModelClassCache cache = getModelClassCache(resolver);
 
-        if (cache == null) {
-            // Thread-safe Identity map to prevent O(N) deep equality checks on the massive map
-            cache = java.util.Collections.synchronizedMap(new java.util.IdentityHashMap<>());
-            resolver.getPropertyMap().put(CACHE_KEY, cache);
-        }
-
-        // Thread-safe inner map using standard equality for the Strings
-        Map<String, Object> mapCache = cache.computeIfAbsent(map, k -> new java.util.concurrent.ConcurrentHashMap<>());
-
-        Object cachedValue = mapCache.get(originalResourceType);
+        Object cachedValue = cache.get(map, originalResourceType);
         if (cachedValue != null) {
             return cachedValue == Object.class ? null : (Class<?>) cachedValue;
         }
+
         Class<?> modelClass = resolveModelClass(originalResourceType, resource, map, resolver);
-        mapCache.put(originalResourceType, modelClass == null ? Object.class : modelClass);
+
+        cache.put(map, originalResourceType, modelClass);
         return modelClass;
     }
 

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -328,7 +328,7 @@ final class AdapterImplementations {
         }
         ResourceResolver resolver = resource.getResourceResolver();
         final String originalResourceType = resource.getResourceType();
-        if (originalResourceType == null) {
+        if (org.apache.commons.lang3.StringUtils.isEmpty(originalResourceType)) {
             return null;
         }
 

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -346,27 +346,36 @@ final class AdapterImplementations {
         if (cachedValue != null) {
             return cachedValue == Object.class ? null : (Class<?>) cachedValue;
         }
-        Class<?> modelClass = getClassFromResourceTypeMap(originalResourceType, map, resolver);
-        if (modelClass == null) {
-            String resourceType = resolver.getParentResourceType(resource);
-            while (resourceType != null) {
-                modelClass = getClassFromResourceTypeMap(resourceType, map, resolver);
-                if (modelClass != null) {
-                    break;
-                } else {
-                    resourceType = resolver.getParentResourceType(resourceType);
-                }
-            }
-            if (modelClass == null) {
-                Resource resourceTypeResource = resolver.getResource(originalResourceType);
-                if (resourceTypeResource != null
-                        && !resourceTypeResource.getPath().equals(resource.getPath())) {
-                    modelClass = getModelClassForResource(resourceTypeResource, map);
-                }
-            }
-        }
+        Class<?> modelClass = resolveModelClass(originalResourceType, resource, map, resolver);
         mapCache.put(originalResourceType, modelClass == null ? Object.class : modelClass);
         return modelClass;
+    }
+
+    private static Class<?> resolveModelClass(
+            final String originalResourceType,
+            final Resource resource,
+            final Map<String, Class<?>> map,
+            final ResourceResolver resolver) {
+        Class<?> modelClass = getClassFromResourceTypeMap(originalResourceType, map, resolver);
+        if (modelClass != null) {
+            return modelClass;
+        }
+
+        String resourceType = resolver.getParentResourceType(resource);
+        while (resourceType != null) {
+            modelClass = getClassFromResourceTypeMap(resourceType, map, resolver);
+            if (modelClass != null) {
+                return modelClass;
+            }
+            resourceType = resolver.getParentResourceType(resourceType);
+        }
+
+        Resource resourceTypeResource = resolver.getResource(originalResourceType);
+        if (resourceTypeResource != null && !resourceTypeResource.getPath().equals(resource.getPath())) {
+            return getModelClassForResource(resourceTypeResource, map);
+        }
+
+        return null;
     }
 
     private static Class<?> getClassFromResourceTypeMap(

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -20,8 +20,6 @@ package org.apache.sling.models.impl;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -330,17 +328,20 @@ final class AdapterImplementations {
         }
         ResourceResolver resolver = resource.getResourceResolver();
         final String originalResourceType = resource.getResourceType();
+        if (originalResourceType == null) {
+            return null;
+        }
 
         Map<Map<String, Class<?>>, Map<String, Object>> cache = getModelClassCache(resolver);
 
         if (cache == null) {
-            cache = new IdentityHashMap<>();
-            // Using IdentityHashMap prevent O(N) deep equality checks on large
-            // ConcurrentHashMaps!
+            // Thread-safe Identity map to prevent O(N) deep equality checks on the massive map
+            cache = java.util.Collections.synchronizedMap(new java.util.IdentityHashMap<>());
             resolver.getPropertyMap().put(CACHE_KEY, cache);
         }
 
-        Map<String, Object> mapCache = cache.computeIfAbsent(map, k -> new HashMap<>());
+        // Thread-safe inner map using standard equality for the Strings
+        Map<String, Object> mapCache = cache.computeIfAbsent(map, k -> new java.util.concurrent.ConcurrentHashMap<>());
 
         Object cachedValue = mapCache.get(originalResourceType);
         if (cachedValue != null) {

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -20,6 +20,8 @@ package org.apache.sling.models.impl;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +51,8 @@ import org.slf4j.LoggerFactory;
 final class AdapterImplementations {
 
     private static final Logger log = LoggerFactory.getLogger(AdapterImplementations.class);
+
+    private static final String CACHE_KEY = "org.apache.sling.models.impl.AdapterImplementations.ModelClassCache";
 
     private final ConcurrentMap<String, ConcurrentNavigableMap<String, ModelClass<?>>> adapterImplementations =
             new ConcurrentHashMap<>();
@@ -314,32 +318,55 @@ final class AdapterImplementations {
         return getModelClassForResource(resource, resourceTypeMappingsForResources);
     }
 
+    @SuppressWarnings("unchecked")
+    private static Map<Map<String, Class<?>>, Map<String, Object>> getModelClassCache(final ResourceResolver resolver) {
+        return (Map<Map<String, Class<?>>, Map<String, Object>>)
+                resolver.getPropertyMap().get(CACHE_KEY);
+    }
+
     protected static Class<?> getModelClassForResource(final Resource resource, final Map<String, Class<?>> map) {
         if (resource == null) {
             return null;
         }
         ResourceResolver resolver = resource.getResourceResolver();
         final String originalResourceType = resource.getResourceType();
+
+        Map<Map<String, Class<?>>, Map<String, Object>> cache = getModelClassCache(resolver);
+
+        if (cache == null) {
+            cache = new IdentityHashMap<>();
+            // Using IdentityHashMap prevent O(N) deep equality checks on large
+            // ConcurrentHashMaps!
+            resolver.getPropertyMap().put(CACHE_KEY, cache);
+        }
+
+        Map<String, Object> mapCache = cache.computeIfAbsent(map, k -> new HashMap<>());
+
+        Object cachedValue = mapCache.get(originalResourceType);
+        if (cachedValue != null) {
+            return cachedValue == Object.class ? null : (Class<?>) cachedValue;
+        }
         Class<?> modelClass = getClassFromResourceTypeMap(originalResourceType, map, resolver);
-        if (modelClass != null) {
-            return modelClass;
-        } else {
+        if (modelClass == null) {
             String resourceType = resolver.getParentResourceType(resource);
             while (resourceType != null) {
                 modelClass = getClassFromResourceTypeMap(resourceType, map, resolver);
                 if (modelClass != null) {
-                    return modelClass;
+                    break;
                 } else {
                     resourceType = resolver.getParentResourceType(resourceType);
                 }
             }
-            Resource resourceTypeResource = resolver.getResource(originalResourceType);
-            if (resourceTypeResource != null && !resourceTypeResource.getPath().equals(resource.getPath())) {
-                return getModelClassForResource(resourceTypeResource, map);
-            } else {
-                return null;
+            if (modelClass == null) {
+                Resource resourceTypeResource = resolver.getResource(originalResourceType);
+                if (resourceTypeResource != null
+                        && !resourceTypeResource.getPath().equals(resource.getPath())) {
+                    modelClass = getModelClassForResource(resourceTypeResource, map);
+                }
             }
         }
+        mapCache.put(originalResourceType, modelClass == null ? Object.class : modelClass);
+        return modelClass;
     }
 
     private static Class<?> getClassFromResourceTypeMap(

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -370,9 +370,11 @@ final class AdapterImplementations {
             resourceType = resolver.getParentResourceType(resourceType);
         }
 
-        Resource resourceTypeResource = resolver.getResource(originalResourceType);
-        if (resourceTypeResource != null && !resourceTypeResource.getPath().equals(resource.getPath())) {
-            return getModelClassForResource(resourceTypeResource, map);
+        if (originalResourceType != null) {
+            Resource resourceTypeResource = resolver.getResource(originalResourceType);
+            if (resourceTypeResource != null && !resourceTypeResource.getPath().equals(resource.getPath())) {
+                return getModelClassForResource(resourceTypeResource, map);
+            }
         }
 
         return null;

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -328,7 +328,7 @@ final class AdapterImplementations {
         }
         ResourceResolver resolver = resource.getResourceResolver();
         final String originalResourceType = resource.getResourceType();
-        if (org.apache.commons.lang3.StringUtils.isEmpty(originalResourceType)) {
+        if (originalResourceType.isEmpty()) {
             return null;
         }
 
@@ -371,11 +371,9 @@ final class AdapterImplementations {
             resourceType = resolver.getParentResourceType(resourceType);
         }
 
-        if (originalResourceType != null) {
-            Resource resourceTypeResource = resolver.getResource(originalResourceType);
-            if (resourceTypeResource != null && !resourceTypeResource.getPath().equals(resource.getPath())) {
-                return getModelClassForResource(resourceTypeResource, map);
-            }
+        Resource resourceTypeResource = resolver.getResource(originalResourceType);
+        if (resourceTypeResource != null && !resourceTypeResource.getPath().equals(resource.getPath())) {
+            return getModelClassForResource(resourceTypeResource, map);
         }
 
         return null;
@@ -383,9 +381,6 @@ final class AdapterImplementations {
 
     private static Class<?> getClassFromResourceTypeMap(
             final String resourceType, final Map<String, Class<?>> map, final ResourceResolver resolver) {
-        if (resourceType == null) {
-            return null;
-        }
         Class<?> modelClass = map.get(resourceType);
         if (modelClass == null) {
             for (String searchPath : resolver.getSearchPath()) {

--- a/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
+++ b/src/main/java/org/apache/sling/models/impl/AdapterImplementations.java
@@ -52,7 +52,7 @@ final class AdapterImplementations {
 
     private static final Logger log = LoggerFactory.getLogger(AdapterImplementations.class);
 
-    private static final String CACHE_KEY = "org.apache.sling.models.impl.AdapterImplementations.ModelClassCache";
+    private static final String CACHE_KEY = AdapterImplementations.class.getName() + ".ModelClassCache";
 
     private final ConcurrentMap<String, ConcurrentNavigableMap<String, ModelClass<?>>> adapterImplementations =
             new ConcurrentHashMap<>();

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -319,7 +319,7 @@ class AdapterImplementationsTest {
 
     @Test
     void testResourceTypeRegistrationForResourceWithoutResourceType() {
-        lenient().when(resource.getResourceType()).thenReturn(null);
+        lenient().when(resource.getResourceType()).thenReturn("");
         lenient().when(resource.getResourceResolver()).thenReturn(resourceResolver);
         lenient().when(resourceResolver.getSearchPath()).thenReturn(new String[] {"/apps/", "/libs/"});
 

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -20,7 +20,6 @@ package org.apache.sling.models.impl;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.Map;
 
 import org.apache.sling.api.SlingJakartaHttpServletRequest;
@@ -40,7 +39,6 @@ import org.osgi.framework.BundleContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -344,7 +342,6 @@ class AdapterImplementationsTest {
         Map<Map<String, Class<?>>, Map<String, Object>> cache = (Map<Map<String, Class<?>>, Map<String, Object>>)
                 propertyMap.get(AdapterImplementations.class.getName() + ".ModelClassCache");
         assertNotNull(cache);
-        assertTrue(cache instanceof IdentityHashMap, "Expected the cache to be an IdentityHashMap");
 
         assertNull(underTest.getModelClassForResource(resource));
 

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -342,7 +342,7 @@ class AdapterImplementationsTest {
 
         @SuppressWarnings("unchecked")
         Map<Map<String, Class<?>>, Map<String, Object>> cache = (Map<Map<String, Class<?>>, Map<String, Object>>)
-                propertyMap.get("org.apache.sling.models.impl.AdapterImplementations.ModelClassCache");
+                propertyMap.get(AdapterImplementations.class.getName() + ".ModelClassCache");
         assertNotNull(cache);
         assertTrue(cache instanceof IdentityHashMap, "Expected the cache to be an IdentityHashMap");
 

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -19,6 +19,9 @@
 package org.apache.sling.models.impl;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -35,8 +38,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.osgi.framework.BundleContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -320,6 +327,28 @@ class AdapterImplementationsTest {
 
         // ensure we don't have any registrations and no exception is thrown
         assertNull(underTest.getModelClassForResource(resource));
+    }
+
+    @Test
+    void testCacheIsUsedForModelClassForResource() {
+        Map<String, Object> propertyMap = new HashMap<>();
+        lenient().when(resource.getResourceType()).thenReturn("sling/rt/one");
+        lenient().when(resource.getResourceResolver()).thenReturn(resourceResolver);
+        lenient().when(resourceResolver.getPropertyMap()).thenReturn(propertyMap);
+        lenient().when(resourceResolver.getParentResourceType(resource)).thenReturn(null);
+        lenient().when(resourceResolver.getSearchPath()).thenReturn(new String[] {"/apps/", "/libs/"});
+
+        assertNull(underTest.getModelClassForResource(resource));
+
+        @SuppressWarnings("unchecked")
+        Map<Map<String, Class<?>>, Map<String, Object>> cache = (Map<Map<String, Class<?>>, Map<String, Object>>)
+                propertyMap.get("org.apache.sling.models.impl.AdapterImplementations.ModelClassCache");
+        assertNotNull(cache);
+        assertTrue(cache instanceof IdentityHashMap, "Expected the cache to be an IdentityHashMap");
+
+        assertNull(underTest.getModelClassForResource(resource));
+
+        verify(resourceResolver, times(1)).getSearchPath();
     }
 
     static final class NoneImplementationPicker implements ImplementationPicker {

--- a/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
+++ b/src/test/java/org/apache/sling/models/impl/AdapterImplementationsTest.java
@@ -338,9 +338,7 @@ class AdapterImplementationsTest {
 
         assertNull(underTest.getModelClassForResource(resource));
 
-        @SuppressWarnings("unchecked")
-        Map<Map<String, Class<?>>, Map<String, Object>> cache = (Map<Map<String, Class<?>>, Map<String, Object>>)
-                propertyMap.get(AdapterImplementations.class.getName() + ".ModelClassCache");
+        Object cache = propertyMap.get(AdapterImplementations.class.getName() + ".ModelClassCache");
         assertNotNull(cache);
 
         assertNull(underTest.getModelClassForResource(resource));


### PR DESCRIPTION
Issue : SLING-12217

While SLING-12244 fixed the database side of these duplicate lookups, `AdapterImplementations.lookup()` was still hammering the CPU by re-evaluating search paths and querying the large `ConcurrentHashMap` hundreds of times per page render for the same exact resource type

changes:
- Request scoped Cache: attach a cache directly to `ResourceResolver.getPropertyMap()` so it lives and dies with the HTTP request
- Thread Safe Identity Caching: The outer cache uses `Collections.synchronizedMap(new IdentityHashMap<>())` to safely bypass expensive O(N) deep equality checks without crashing multi-threaded integration tests
- Thread Safe Inner Cache: Uses a standard `ConcurrentHashMap` for concurrent string lookups
- Remembering Not Found Results: We use a placeholder (Object.class) to remember when a resource type doesn't have a model. This lets us instantly abort future checks instead of endlessly re-walking the JCR tree looking for something that isn't there.

Let me know what you think?